### PR TITLE
Early support for assertions

### DIFF
--- a/ubuntu_image/_unstable.py
+++ b/ubuntu_image/_unstable.py
@@ -1,0 +1,602 @@
+"""
+This module contains unstable APIs for things that will be delegated to other
+tools later. While we will do our best not to break those APIs when the
+implementation changes, this is not guaranteed.
+"""
+import enum
+import functools
+import gettext
+import logging
+import os
+import re
+import textwrap
+
+_ = gettext.gettext
+
+_logger = logging.getLogger("ubuntu-image")
+
+
+def normalize_rfc822_value(value):
+    # Remove the multi-line dot marker
+    value = re.sub('^(\s*)\.$', '\\1', value, flags=re.M)
+    # Remove consistent indentation
+    value = textwrap.dedent(value)
+    # Strip the remaining whitespace
+    value = value.strip()
+    return value
+
+
+class OriginMode(enum.Enum):
+
+    """Possible "modes" an :class:`Origin` can operate in."""
+
+    whole_file = 'whole-file'
+    single_line = 'single-line'
+    line_range = 'line-range'
+
+
+@functools.total_ordering
+class Origin:
+
+    """
+    Simple class for tracking where something came from.
+
+    This class supports "pinpointing" something in a block of text. The block
+    is described by the source attribute. The actual range is described by
+    line_start (inclusive) and line_end (exclusive).
+
+    :attribute source:
+        Something that describes where the text came from.
+
+    :attribute line_start:
+        The number of the line where the record begins. This can be None
+        when the intent is to cover the whole file. This can also be equal
+        to line_end (when not None) if the intent is to show a single line.
+
+    :attribute line_end:
+        The number of the line where the record ends
+    """
+
+    __slots__ = ['source', 'line_start', 'line_end']
+
+    def __init__(self, source, line_start=None, line_end=None):
+        self.source = source
+        self.line_start = line_start
+        self.line_end = line_end
+
+    def mode(self):
+        """
+        Compute the "mode" of this origin instance.
+
+        :returns:
+            :attr:`OriginMode.whole_file`, :attr:`OriginMode.single_line`
+            or :attr:`OriginMode.line_range`.
+
+        The mode tells if this instance is describing the whole file,
+        a range of lines or just a single line. It is mostly used internally
+        by the implementation.
+        """
+        if self.line_start is None and self.line_end is None:
+            return OriginMode.whole_file
+        elif self.line_start == self.line_end:
+            return OriginMode.single_line
+        else:
+            return OriginMode.line_range
+
+    def __repr__(self):
+        return "<{} source:{!r} line_start:{} line_end:{}>".format(
+            self.__class__.__name__,
+            self.source, self.line_start, self.line_end)
+
+    def __str__(self):
+        mode = self.mode()
+        if mode is OriginMode.whole_file:
+            return str(self.source)
+        elif mode is OriginMode.single_line:
+            return "{}:{}".format(self.source, self.line_start)
+        elif mode is OriginMode.line_range:
+            return "{}:{}-{}".format(
+                self.source, self.line_start, self.line_end)
+        else:
+            raise NotImplementedError
+
+    def relative_to(self, base_dir):
+        """
+        Create a Origin with source relative to the specified base directory.
+
+        :param base_dir:
+            A base directory name
+        :returns:
+            A new Origin with source replaced by the result of calling
+            relative_to(base_dir) on the current source *iff* the current
+            source has that method, self otherwise.
+
+        This method is useful for obtaining user friendly Origin objects that
+        have short, understandable filenames.
+        """
+        relative_source = self.source.relative_to(base_dir)
+        if relative_source is not self.source:
+            return Origin(relative_source, self.line_start, self.line_end)
+        else:
+            return self
+
+    def with_offset(self, offset):
+        """
+        Create a new Origin by adding a offset of a specific number of lines.
+
+        :param offset:
+            Number of lines to add (or subtract)
+        :returns:
+            A new Origin object
+        """
+        mode = self.mode()
+        if mode is OriginMode.whole_file:
+            return self
+        elif mode is OriginMode.single_line or mode is OriginMode.line_range:
+            return Origin(
+                self.source, self.line_start + offset, self.line_end + offset)
+        else:
+            raise NotImplementedError
+
+    def just_line(self):
+        """
+        Create a new Origin that points to the start line.
+
+        :returns:
+            A new Origin with the end_line equal to start_line.
+            This effectively makes the origin describe a single line.
+        """
+        return Origin(self.source, self.line_start, self.line_start)
+
+    def just_file(self):
+        """
+        create a new Origin that points to the whole file.
+
+        :returns:
+            A new Origin with line_end and line_start both set to None.
+        """
+        return Origin(self.source)
+
+    def __eq__(self, other):
+        if isinstance(other, Origin):
+            return ((self.source, self.line_start, self.line_end) ==
+                    (other.source, other.line_start, other.line_end))
+        else:
+            return NotImplemented
+
+    def __gt__(self, other):
+        if isinstance(other, Origin):
+            return ((self.source, self.line_start, self.line_end) >
+                    (other.source, other.line_start, other.line_end))
+        else:
+            return NotImplemented
+
+
+@functools.total_ordering
+class UnknownTextSource():
+
+    """
+    Class indicating that the source of text is unknown.
+
+    This instances of this class are constructed by gen_rfc822_records() when
+    no explicit source is provided and the stream has no name.
+    """
+
+    def __str__(self):
+        return _("???")
+
+    def __repr__(self):
+        return "{}()".format(self.__class__.__name__)
+
+    def __eq__(self, other):
+        if isinstance(other, UnknownTextSource):
+            return True
+        else:
+            return False
+
+    def __gt__(self, other):
+        if isinstance(other, UnknownTextSource):
+            return False
+        else:
+            return NotImplemented
+
+    def relative_to(self, path):
+        return self
+
+
+@functools.total_ordering
+class FileTextSource:
+
+    """
+    Class indicating that text came from a file.
+
+    :attribute filename:
+        name of the file something comes from
+    """
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __str__(self):
+        return self.filename
+
+    def __repr__(self):
+        return "{}({!r})".format(
+            self.__class__.__name__, self.filename)
+
+    def __eq__(self, other):
+        if isinstance(other, FileTextSource):
+            return self.filename == other.filename
+        else:
+            return False
+
+    def __gt__(self, other):
+        if isinstance(other, FileTextSource):
+            return self.filename > other.filename
+        else:
+            return NotImplemented
+
+    def relative_to(self, base_dir):
+        """
+        Compute a FileTextSource with the filename being a relative path from
+        the specified base directory.
+
+        :param base_dir:
+            A base directory name
+        :returns:
+            A new FileTextSource with filename relative to that base_dir
+        """
+        return self.__class__(os.path.relpath(self.filename, base_dir))
+
+
+class RFC822Record:
+
+    """
+    Class for tracking RFC822 records.
+
+    This is a simple container for the dictionary of data. The data is
+    represented by two copies, one original and one after value normalization.
+    Value normalization strips out excess whitespace and processes the magic
+    leading dot syntax that is essential for empty newlines.
+
+    Comparison is performed on the normalized data only, raw data is stored for
+    reference but does not differentiate records.
+
+    Each instance also holds the origin of the data (location of the
+    file/stream where it was parsed from).
+    """
+
+    def __init__(self, data, origin=None, raw_data=None,
+                 field_offset_map=None):
+        """
+        Initialize a new record.
+
+        :param data:
+            A dictionary with normalized record data
+        :param origin:
+            A :class:`Origin` instance that describes where the data came from
+        :param raw_data:
+            An optional dictionary with raw record data. If omitted then it
+            will default to normalized data (as the same object, without making
+            a copy)
+        :param field_offset_map:
+            An optional dictionary with offsets (in line numbers) of each field
+        """
+        self._data = data
+        if raw_data is None:
+            raw_data = data
+        self._raw_data = raw_data
+        self._origin = origin
+        self._field_offset_map = field_offset_map
+
+    def __repr__(self):
+        return "<{} data:{!r} origin:{!r}>".format(
+            self.__class__.__name__, self._data, self._origin)
+
+    def __eq__(self, other):
+        if isinstance(other, RFC822Record):
+            return (self._data, self._origin) == (other._data, other._origin)
+        return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, RFC822Record):
+            return (self._data, self._origin) != (other._data, other._origin)
+        return NotImplemented
+
+    @property
+    def data(self):
+        """
+        The normalized version of the data set (dictionary)
+
+        This property exposes the normalized version of the data encapsulated
+        in this record. Normalization is performed with
+        :func:`normalize_rfc822_value()`. Only values are normalized, keys are
+        left intact.
+        """
+        return self._data
+
+    @property
+    def raw_data(self):
+        """
+        The raw version of data set (dictionary).
+
+        This property exposes the raw (original) version of the data
+        encapsulated by this record. This data is as it was originally parsed,
+        including all the whitespace layout.
+
+        In some records this may be 'normal' data object itself (same object).
+        """
+        return self._raw_data
+
+    @property
+    def origin(self):
+        """The origin of the record."""
+        return self._origin
+
+    @property
+    def field_offset_map(self):
+        """
+        The field-to-line-number-offset mapping.
+
+        A dictionary mapping field name to offset (in lines) relative to the
+        origin where that field definition commences.
+
+        Note: the return value may be None
+        """
+        return self._field_offset_map
+
+    def dump(self, stream):
+        """Dump this record to a stream."""
+        def _dump_part(stream, key, values):
+            stream.write("{}:\n".format(key))
+            for value in values:
+                if not value:
+                    stream.write(" .\n")
+                elif value == ".":
+                    stream.write(" ..\n")
+                else:
+                    stream.write(" {}\n".format(value))
+        for key, value in self.data.items():
+            if isinstance(value, (list, tuple)):
+                _dump_part(stream, key, value)
+            elif isinstance(value, str) and "\n" in value:
+                values = value.split("\n")
+                if not values[-1]:
+                    values = values[:-1]
+                _dump_part(stream, key, values)
+            else:
+                stream.write("{}: {}\n".format(key, value))
+        stream.write("\n")
+
+
+class RFC822SyntaxError(SyntaxError):
+
+    """SyntaxError subclass for RFC822 parsing functions"""
+
+    def __init__(self, filename, lineno, msg):
+        self.filename = filename
+        self.lineno = lineno
+        self.msg = msg
+
+    def __repr__(self):
+        return "{}({!r}, {!r}, {!r})".format(
+            self.__class__.__name__, self.filename, self.lineno, self.msg)
+
+    def __eq__(self, other):
+        if isinstance(other, RFC822SyntaxError):
+            return ((self.filename, self.lineno, self.msg) == (
+                other.filename, other.lineno, other.msg))
+        return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, RFC822SyntaxError):
+            return ((self.filename, self.lineno, self.msg) != (
+                other.filename, other.lineno, other.msg))
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.filename, self.lineno, self.msg))
+
+
+def load_rfc822_records(stream, data_cls=dict, source=None):
+    """
+    Load a sequence of rfc822-like records from a text stream.
+
+    :param stream:
+        A file-like object from which to load the rfc822 data
+    :param data_cls:
+        The class of the dictionary-like type to hold the results. This is
+        mainly there so that callers may pass collections.OrderedDict.
+    :param source:
+        An object that describes where stream data is coming from.
+
+        If None, it will be inferred from the stream (if possible). Specialized
+        callers should provider a custom source object to allow developers to
+        accurately keep track of where (possibly problematic) RFC822 data is
+        coming from. If this is None and inferring fails then all of the loaded
+        records will have a None origin.
+
+    Each record consists of any number of key-value pairs. Subsequent records
+    are separated by one blank line. A record key may have a multi-line value
+    if the line starts with whitespace character.
+
+    Returns a list of subsequent values as instances RFC822Record class.  If
+    the optional data_cls argument is collections.OrderedDict then the values
+    retain their original ordering.
+    """
+    return list(gen_rfc822_records(stream, data_cls, source))
+
+
+def gen_rfc822_records(stream, data_cls=dict, source=None):
+    """
+    Load a sequence of rfc822-like records from a text stream.
+
+    :param stream:
+        A file-like object from which to load the rfc822 data
+    :param data_cls:
+        The class of the dictionary-like type to hold the results. This is
+        mainly there so that callers may pass collections.OrderedDict.
+    :param source:
+        An object that describes where stream data is coming from.
+
+        If None, it will be inferred from the stream (if possible). Specialized
+        callers should provider a custom source object to allow developers to
+        accurately keep track of where (possibly problematic) RFC822 data is
+        coming from. If this is None and inferring fails then all of the loaded
+        records will have a None origin.
+
+    Each record consists of any number of key-value pairs. Subsequent records
+    are separated by one blank line. A record key may have a multi-line value
+    if the line starts with whitespace character.
+
+    Returns a list of subsequent values as instances RFC822Record class. If
+    the optional data_cls argument is collections.OrderedDict then the values
+    retain their original ordering.
+    """
+    record = None
+    key = None
+    value_list = None
+    origin = None
+    field_offset_map = None
+    # If the source was not provided then try constructing a FileTextSource
+    # from the name of the stream. If that fails, keep using None.
+    if source is None:
+        try:
+            source = FileTextSource(stream.name)
+        except AttributeError:
+            source = UnknownTextSource()
+
+    def _syntax_error(msg):
+        """Report a syntax error in the current line."""
+        try:
+            filename = stream.name
+        except AttributeError:
+            filename = None
+        return RFC822SyntaxError(filename, lineno, msg)
+
+    def _new_record():
+        """Reset local state to track new record."""
+        nonlocal key
+        nonlocal value_list
+        nonlocal record
+        nonlocal origin
+        nonlocal field_offset_map
+        key = None
+        value_list = None
+        if source is not None:
+            origin = Origin(source, None, None)
+        field_offset_map = {}
+        record = RFC822Record(data_cls(), origin, data_cls(), field_offset_map)
+
+    def _commit_key_value_if_needed():
+        """Finalize the most recently seen key: value pair."""
+        nonlocal key
+        if key is not None:
+            raw_value = ''.join(value_list)
+            normalized_value = normalize_rfc822_value(raw_value)
+            record.raw_data[key] = raw_value
+            record.data[key] = normalized_value
+            _logger.debug(_("Committed key/value %r=%r"), key,
+                          normalized_value)
+            key = None
+
+    def _set_start_lineno_if_needed():
+        """Remember the line number of the record start unless already set."""
+        if origin and record.origin.line_start is None:
+            record.origin.line_start = lineno
+
+    def _update_end_lineno():
+        """Update the line number of the record tail."""
+        if origin:
+            record.origin.line_end = lineno
+
+    # Start with an empty record
+    _new_record()
+    # Support simple text strings
+    if isinstance(stream, str):
+        # keepends=True (python3.2 has no keyword for this)
+        stream = iter(stream.splitlines(True))
+    # Iterate over subsequent lines of the stream
+    for lineno, line in enumerate(stream, start=1):
+        _logger.debug(_("Looking at line %d:%r"), lineno, line)
+        # Treat # as comments
+        if line.startswith("#"):
+            pass
+        # Treat empty lines as record separators
+        elif line.strip() == "":
+            # Commit the current record so that the multi-line value of the
+            # last key, if any, is saved as a string
+            _commit_key_value_if_needed()
+            # If data is non-empty, yield the record, this allows us to safely
+            # use newlines for formatting
+            if record.data:
+                _logger.debug(_("yielding record: %r"), record)
+                yield record
+            # Reset local state so that we can build a new record
+            _new_record()
+        # Treat lines staring with whitespace as multi-line continuation of the
+        # most recently seen key-value
+        elif line.startswith(" "):
+            if key is None:
+                # If we have not seen any keys yet then this is a syntax error
+                raise _syntax_error(_("Unexpected multi-line value"))
+            # Strip the initial space. This matches the behavior of xgettext
+            # scanning our job definitions with multi-line values.
+            line = line[1:]
+            # Append the current line to the list of values of the most recent
+            # key. This prevents quadratic complexity of string concatenation
+            value_list.append(line)
+            # Update the end line location of this record
+            _update_end_lineno()
+        # Treat lines with a colon as new key-value pairs
+        elif ":" in line:
+            # Since this is actual data let's try to remember where it came
+            # from. This may be a no-operation if there were any preceding
+            # key-value pairs.
+            _set_start_lineno_if_needed()
+            # Since we have a new, key-value pair we need to commit any
+            # previous key that we may have (regardless of multi-line or
+            # single-line values).
+            _commit_key_value_if_needed()
+            # Parse the line by splitting on the colon, getting rid of
+            # all surrounding whitespace from the key and getting rid of the
+            # leading whitespace from the value.
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.lstrip()
+            # Check if the key already exist in this message
+            if key in record.data:
+                raise _syntax_error(_(
+                    "Job has a duplicate key {!r} "
+                    "with old value {!r} and new value {!r}"
+                ).format(key, record.raw_data[key], value))
+            if value.strip() != "":
+                # Construct initial value list out of the (only) value that we
+                # have so far. Additional multi-line values will just append to
+                # value_list
+                value_list = [value]
+                # Store the offset of the filed in the offset map
+                field_offset_map[key] = lineno - origin.line_start
+            else:
+                # The initial line may be empty, in that case the spaces and
+                # newlines there are discarded
+                value_list = []
+                # Store the offset of the filed in the offset map
+                # The +1 is for the fact that value is empty (or just
+                # whitespace) and that is stripped away in the normalized data
+                # part of the RFC822 record. To keep line tracking accurate
+                # we just assume that the field actually starts on
+                # the following line.
+                field_offset_map[key] = lineno - origin.line_start + 1
+            # Update the end-line location
+            _update_end_lineno()
+        # Treat all other lines as syntax errors
+        else:
+            raise _syntax_error(
+                _("Unexpected non-empty line: {!r}").format(line))
+    # Make sure to commit the last key from the record
+    _commit_key_value_if_needed()
+    # Once we've seen the whole file return the last record, if any
+    if record.data:
+        _logger.debug(_("yielding record: %r"), record)
+        yield record

--- a/ubuntu_image/assertions.py
+++ b/ubuntu_image/assertions.py
@@ -1,0 +1,70 @@
+from io import StringIO
+from ubuntu_image._unstable import load_rfc822_records
+
+__all__ = ('Assertion', 'ModelAssertion')
+
+
+class Assertion:
+
+    """
+    Assertion is a fact encoded in a text file.
+
+    Assertions are used heavily in snappy. The format of an assertion is
+    similar to RFC822 but they are not meant to be read or written by humans
+    and they contain a cryptographic signature.
+    """
+
+    def __init__(self, headers, body=None):
+        """Initialize an assertion with the following data (headers)."""
+        self.headers = headers
+        self.body = body
+
+    @classmethod
+    def from_string(cls, text):
+        """Load assertion from a string."""
+        # XXX: This is a temporary stop-gap. The proper way to do this is to
+        # invoke yet-unimplemented go executable that reads an assertion on
+        # stdin, validates it and outputs the same assertion as JSON on stdout.
+        records = load_rfc822_records(StringIO(text))
+        if len(records) != 1:
+            raise ValueError("Expected exactly one assertion")
+        headers = records[0].data
+        body = None  # XXX: body is not required here
+        return cls(headers, body)
+
+
+class header:
+
+    """Descriptor for accessing assertion headers conveniently."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return 'header({!a})'.format(self.name)
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return instance.headers[self.name]
+
+
+class ModelAssertion(Assertion):
+
+    """
+    Model assertion describes a class of devices sharing the model name.
+
+    The assertion contains, among other things, the identifier of the store
+    and of the three key snaps (core, kernel, gadget) that have to be
+    installed.
+    """
+
+    type = header('type')
+    authority_id = header('authority-id')
+    series = header('series')
+    brand_id = header('brand-id')
+    os = header('os')
+    architecture = header('architecture')
+    kernel = header('kernel')
+    gadget = header('gadget')
+    required_snaps = header('required-snaps')

--- a/ubuntu_image/test_assertions.py
+++ b/ubuntu_image/test_assertions.py
@@ -1,0 +1,34 @@
+import unittest
+
+from ubuntu_image.assertions import ModelAssertion
+
+fake_model_assertion = """
+type: model
+authority-id: nobody
+series: 16
+brand-id: zygoon
+model: kvm-demo
+os: ubuntu-core
+architecture: amd64 
+kernel: canonical-pc-linux
+gadget: canonical-pc
+required-snaps: links
+# preinstalled-snaps: a, b
+# prefetched-snaps: docker
+body-size: 0
+"""
+# TODO: add a fake body and signature once the parser understands it
+
+class ModelAssertionTest(unittest.TestCase):
+
+    def test_smoke(self):
+        model = ModelAssertion.from_string(fake_model_assertion)
+        self.assertEqual(model.type, "model")
+        self.assertEqual(model.authority_id, "nobody")
+        self.assertEqual(model.series, "16")
+        self.assertEqual(model.brand_id, "zygoon")
+        self.assertEqual(model.os, "ubuntu-core")
+        self.assertEqual(model.architecture, "amd64")
+        self.assertEqual(model.kernel, "canonical-pc-linux")
+        self.assertEqual(model.gadget, "canonical-pc")
+        self.assertEqual(model.required_snaps, "links")

--- a/ubuntu_image/test_unstable.py
+++ b/ubuntu_image/test_unstable.py
@@ -1,0 +1,892 @@
+"""Test definitions for ubuntu_image.unstable module."""
+
+from io import StringIO
+from unittest import TestCase
+import os
+
+from ubuntu_image._unstable import FileTextSource
+from ubuntu_image._unstable import Origin
+from ubuntu_image._unstable import UnknownTextSource
+from ubuntu_image._unstable import RFC822Record
+from ubuntu_image._unstable import RFC822SyntaxError
+from ubuntu_image._unstable import load_rfc822_records
+from ubuntu_image._unstable import normalize_rfc822_value
+
+
+class NormalizationTests(TestCase):
+
+    """Tests for normalize_rfc822_value()"""
+
+    def test_smoke(self):
+        n = normalize_rfc822_value
+        self.assertEqual(n("foo"), "foo")
+        self.assertEqual(n(" foo"), "foo")
+        self.assertEqual(n("foo "), "foo")
+        self.assertEqual(n(" foo "), "foo")
+        self.assertEqual(n("  foo\n"
+                           "  bar\n"),
+                         ("foo\n"
+                          "bar"))
+
+    def test_dot_handling(self):
+        n = normalize_rfc822_value
+        # single leading dot is stripped
+        self.assertEqual(n("foo\n"
+                           ".\n"
+                           "bar\n"),
+                         ("foo\n"
+                          "\n"
+                          "bar"))
+        # the dot is stripped even if whitespace is present
+        self.assertEqual(n("  foo\n"
+                           "  .\n"
+                           "  bar\n"),
+                         ("foo\n"
+                          "\n"
+                          "bar"))
+        # Two dots don't invoke the special behaviour though
+        self.assertEqual(n("  foo\n"
+                           "  ..\n"
+                           "  bar\n"),
+                         ("foo\n"
+                          "..\n"
+                          "bar"))
+        # Regardless of whitespace
+        self.assertEqual(n("foo\n"
+                           "..\n"
+                           "bar\n"),
+                         ("foo\n"
+                          "..\n"
+                          "bar"))
+
+
+class RFC822RecordTests(TestCase):
+
+    def setUp(self):
+        self.raw_data = {'key': ' value'}
+        self.data = {'key': 'value'}
+        self.origin = Origin(FileTextSource('file.txt'), 1, 1)
+        self.record = RFC822Record(self.data, self.origin, self.raw_data)
+
+    def test_raw_data(self):
+        self.assertEqual(self.record.raw_data, self.raw_data)
+
+    def test_data(self):
+        self.assertEqual(self.record.data, self.data)
+
+    def test_origin(self):
+        self.assertEqual(self.record.origin, self.origin)
+
+    def test_equality(self):
+        # Equality is compared by normalized data, the raw data doesn't count
+        other_raw_data = {'key': 'value '}
+        # This other raw data is actually different to the one we're going to
+        # test against
+        self.assertNotEqual(other_raw_data, self.raw_data)
+        # Let's make another record with different raw data
+        other_record = RFC822Record(self.data, self.origin, other_raw_data)
+        # The normalized data is identical
+        self.assertEqual(other_record.data, self.record.data)
+        # The raw data is not
+        self.assertNotEqual(other_record.raw_data, self.record.raw_data)
+        # The origin is the same (just a sanity check)
+        self.assertEqual(other_record.origin, self.record.origin)
+        # Let's look at the whole object, they should be equal
+        self.assertTrue(other_record == self.record)
+        self.assertTrue(not(other_record != self.record))
+
+
+class RFC822ParserTests(TestCase):
+
+    loader = load_rfc822_records
+
+    def test_empty(self):
+        with StringIO("") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 0)
+
+    def test_parsing_strings_preserves_newlines(self):
+        """
+        Ensure that the special behavior, when a string is passed instead of a
+        stream, is parsed the same way as regular streams are, that is, that
+        newlines are preserved.
+        """
+        text = ("key:\n"
+                " line1\n"
+                " line2\n")
+        records_str = type(self).loader(text)
+        with StringIO(text) as stream:
+            records_stream = type(self).loader(stream)
+        self.assertEqual(records_str, records_stream)
+
+    def test_preserves_whitespace1(self):
+        with StringIO("key: value ") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].raw_data, {'key': 'value '})
+
+    def test_preserves_whitespace2(self):
+        with StringIO("key:\n value ") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].raw_data, {'key': 'value '})
+
+    def test_strips_newlines1(self):
+        with StringIO("key: value \n") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].raw_data, {'key': 'value \n'})
+
+    def test_strips_newlines2(self):
+        with StringIO("key:\n value \n") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].raw_data, {'key': 'value \n'})
+
+    def test_single_record(self):
+        with StringIO("key:value") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].raw_data, {'key': 'value'})
+
+    def test_comments(self):
+        """
+        Ensure that comments are stripped and don't break multi-line handling
+        """
+        text = (
+            "# this is a comment\n"
+            "key:\n"
+            " multi-line value\n"
+            "# this is a comment\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': 'multi-line value'})
+        self.assertEqual(records[0].raw_data, {'key': 'multi-line value\n'})
+
+    def test_dot_escape(self):
+        """
+        Ensure that the dot is not processed in any way
+
+        This part of the code is now handled by another layer.
+        """
+        text = (
+            "key: something\n"
+            " .\n"
+            " .this\n"
+            " ..should\n"
+            " ...work\n"
+        )
+        expected_value = (
+            "something\n"
+            "\n"
+            ".this\n"
+            "..should\n"
+            "...work"
+        )
+        expected_raw_value = (
+            "something\n"
+            ".\n"
+            ".this\n"
+            "..should\n"
+            "...work\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': expected_value})
+        self.assertEqual(records[0].raw_data, {'key': expected_raw_value})
+
+    def test_many_newlines(self):
+        text = (
+            "\n"
+            "\n"
+            "key1:value1\n"
+            "\n"
+            "\n"
+            "\n"
+            "key2:value2\n"
+            "\n"
+            "\n"
+            "key3:value3\n"
+            "\n"
+            "\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 3)
+        self.assertEqual(records[0].data, {'key1': 'value1'})
+        self.assertEqual(records[1].data, {'key2': 'value2'})
+        self.assertEqual(records[2].data, {'key3': 'value3'})
+        self.assertEqual(records[0].raw_data, {'key1': 'value1\n'})
+        self.assertEqual(records[1].raw_data, {'key2': 'value2\n'})
+        self.assertEqual(records[2].raw_data, {'key3': 'value3\n'})
+
+    def test_many_records(self):
+        text = (
+            "key1:value1\n"
+            "\n"
+            "key2:value2\n"
+            "\n"
+            "key3:value3\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 3)
+        self.assertEqual(records[0].data, {'key1': 'value1'})
+        self.assertEqual(records[1].data, {'key2': 'value2'})
+        self.assertEqual(records[2].data, {'key3': 'value3'})
+        self.assertEqual(records[0].raw_data, {'key1': 'value1\n'})
+        self.assertEqual(records[1].raw_data, {'key2': 'value2\n'})
+        self.assertEqual(records[2].raw_data, {'key3': 'value3\n'})
+
+    def test_multiline_value(self):
+        text = (
+            "key:\n"
+            " longer\n"
+            " value\n"
+        )
+        expected_value = (
+            "longer\n"
+            "value"
+        )
+        expected_raw_value = (
+            "longer\n"
+            "value\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': expected_value})
+        self.assertEqual(records[0].raw_data, {'key': expected_raw_value})
+
+    def test_multiline_value_with_space(self):
+        text = (
+            "key:\n"
+            " longer\n"
+            " .\n"
+            " value\n"
+        )
+        expected_value = (
+            "longer\n"
+            "\n"
+            "value"
+        )
+        expected_raw_value = (
+            "longer\n"
+            ".\n"
+            "value\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': expected_value})
+        self.assertEqual(records[0].raw_data, {'key': expected_raw_value})
+
+    def test_multiline_value_with_space__deep_indent(self):
+        """
+        Ensure that equally indented spaces are removed, even if multiple
+        spaces are used (more than one that is typically removed). The raw
+        value should have just the one space removed
+        """
+        text = (
+            "key:\n"
+            "       longer\n"
+            "       .\n"
+            "       value\n"
+        )
+        expected_value = (
+            "longer\n"
+            "\n"
+            "value"
+        )
+        # HINT: exactly as the original above but one space shorter
+        expected_raw_value = (
+            "      longer\n"
+            "      .\n"
+            "      value\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': expected_value})
+        self.assertEqual(records[0].raw_data, {'key': expected_raw_value})
+
+    def test_multiline_value_with_period(self):
+        """
+        Ensure that the dot is not processed in any way
+
+        This part of the code is now handled by another layer.
+        """
+        text = (
+            "key:\n"
+            " longer\n"
+            " ..\n"
+            " value\n"
+        )
+        expected_value = (
+            "longer\n"
+            "..\n"
+            "value"
+        )
+        expected_raw_value = (
+            "longer\n"
+            "..\n"
+            "value\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': expected_value})
+        self.assertEqual(records[0].raw_data, {'key': expected_raw_value})
+
+    def test_many_multiline_values(self):
+        text = (
+            "key1:initial\n"
+            " longer\n"
+            " value 1\n"
+            "\n"
+            "key2:\n"
+            " longer\n"
+            " value 2\n"
+        )
+        expected_value1 = (
+            "initial\n"
+            "longer\n"
+            "value 1"
+        )
+        expected_value2 = (
+            "longer\n"
+            "value 2"
+        )
+        expected_raw_value1 = (
+            "initial\n"
+            "longer\n"
+            "value 1\n"
+        )
+        expected_raw_value2 = (
+            "longer\n"
+            "value 2\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0].data, {'key1': expected_value1})
+        self.assertEqual(records[1].data, {'key2': expected_value2})
+        self.assertEqual(records[0].raw_data, {'key1': expected_raw_value1})
+        self.assertEqual(records[1].raw_data, {'key2': expected_raw_value2})
+
+    def test_proper_parsing_nested_multiline(self):
+        text = (
+            "key:\n"
+            " nested: stuff\n"
+            " even:\n"
+            "  more\n"
+            "  text\n"
+        )
+        expected_value = (
+            "nested: stuff\n"
+            "even:\n"
+            " more\n"
+            " text"
+        )
+        expected_raw_value = (
+            "nested: stuff\n"
+            "even:\n"
+            " more\n"
+            " text\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': expected_value})
+        self.assertEqual(records[0].raw_data, {'key': expected_raw_value})
+
+    def test_proper_parsing_nested_multiline__deep_indent(self):
+        text = (
+            "key:\n"
+            "        nested: stuff\n"
+            "        even:\n"
+            "           more\n"
+            "           text\n"
+        )
+        expected_value = (
+            "nested: stuff\n"
+            "even:\n"
+            "   more\n"
+            "   text"
+        )
+        # HINT: exactly as the original above but one space shorter
+        expected_raw_value = (
+            "       nested: stuff\n"
+            "       even:\n"
+            "          more\n"
+            "          text\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': expected_value})
+        self.assertEqual(records[0].raw_data, {'key': expected_raw_value})
+
+    def test_irrelevant_whitespace(self):
+        text = "key :  value  "
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].raw_data, {'key': 'value  '})
+
+    def test_relevant_whitespace(self):
+        text = (
+            "key:\n"
+            " value\n"
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].raw_data, {'key': 'value\n'})
+
+    def test_bad_multiline(self):
+        text = " extra value"
+        with StringIO(text) as stream:
+            with self.assertRaises(RFC822SyntaxError) as call:
+                type(self).loader(stream)
+            self.assertEqual(call.exception.msg, "Unexpected multi-line value")
+
+    def test_garbage(self):
+        text = "garbage"
+        with StringIO(text) as stream:
+            with self.assertRaises(RFC822SyntaxError) as call:
+                type(self).loader(stream)
+        self.assertEqual(
+            call.exception.msg,
+            "Unexpected non-empty line: 'garbage'")
+
+    def test_syntax_error(self):
+        text = "key1 = value1"
+        with StringIO(text) as stream:
+            with self.assertRaises(RFC822SyntaxError) as call:
+                type(self).loader(stream)
+        self.assertEqual(
+            call.exception.msg,
+            "Unexpected non-empty line: 'key1 = value1'")
+
+    def test_duplicate_error(self):
+        text = (
+            "key1: value1\n"
+            "key1: value2\n"
+        )
+        with StringIO(text) as stream:
+            with self.assertRaises(RFC822SyntaxError) as call:
+                type(self).loader(stream)
+            self.assertEqual(call.exception.msg, (
+                "Job has a duplicate key 'key1' with old value 'value1\\n'"
+                " and new value 'value2\\n'"))
+
+    def test_origin_from_stream_is_Unknown(self):
+        """
+        verify that gen_rfc822_records() uses origin instances with source
+        equal to UnknownTextSource, when no explicit source is provided and the
+        stream has no name to infer a FileTextSource() from.
+        """
+        expected_origin = Origin(UnknownTextSource(), 1, 1)
+        with StringIO("key:value") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].origin, expected_origin)
+
+    def test_origin_from_filename_is_filename(self):
+        # If the test's origin has a filename, we need a valid origin
+        # with proper data.
+        # We're faking the name by using a StringIO subclass with a
+        # name property, which is how rfc822 gets that data.
+        expected_origin = Origin(FileTextSource("file.txt"), 1, 1)
+        with NamedStringIO("key:value",
+                           fake_filename="file.txt") as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data, {'key': 'value'})
+        self.assertEqual(records[0].origin, expected_origin)
+
+    def test_field_offset_map_is_computed(self):
+        text = (
+            "a: value-a\n"  # offset 0
+            "b: value-b\n"  # offset 1
+            "# comment\n"   # offset 2
+            "c:\n"          # offset 3
+            " value-c.1\n"  # offset 4
+            " value-c.2\n"  # offset 5
+            "\n"
+            "d: value-d\n"  # offset 0
+        )
+        with StringIO(text) as stream:
+            records = type(self).loader(stream)
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0].data, {
+            'a': 'value-a',
+            'b': 'value-b',
+            'c': 'value-c.1\nvalue-c.2',
+        })
+        self.assertEqual(records[0].field_offset_map, {
+            'a': 0,
+            'b': 1,
+            'c': 4,
+        })
+        self.assertEqual(records[1].data, {
+            'd': 'value-d',
+        })
+        self.assertEqual(records[1].field_offset_map, {
+            'd': 0,
+        })
+
+
+class NamedStringIO(StringIO):
+
+    """Subclass of StringIO with a name attribute."""
+
+    def __init__(self, string, fake_filename=None):
+        super(NamedStringIO, self).__init__(string)
+        self._fake_filename = fake_filename
+
+    @property
+    def name(self):
+        return(self._fake_filename)
+
+
+class RFC822WriterTests(TestCase):
+
+    """Tests for the :meth:`RFC822Record.dump()` method."""
+
+    def test_single_record(self):
+        with StringIO() as stream:
+            RFC822Record({'key': 'value'}).dump(stream)
+            self.assertEqual(stream.getvalue(), "key: value\n\n")
+
+    def test_multiple_record(self):
+        with StringIO() as stream:
+            RFC822Record({'key1': 'value1', 'key2': 'value2'}).dump(stream)
+            self.assertIn(
+                stream.getvalue(), (
+                    "key1: value1\nkey2: value2\n\n",
+                    "key2: value2\nkey1: value1\n\n"))
+
+    def test_multiline_value(self):
+        text = (
+            "key:\n"
+            " longer\n"
+            " value\n\n"
+        )
+        with StringIO() as stream:
+            RFC822Record({'key': 'longer\nvalue'}).dump(stream)
+            self.assertEqual(stream.getvalue(), text)
+
+    def test_multiline_value_with_space(self):
+        text = (
+            "key:\n"
+            " longer\n"
+            " .\n"
+            " value\n\n"
+        )
+        with StringIO() as stream:
+            RFC822Record({'key': 'longer\n\nvalue'}).dump(stream)
+            self.assertEqual(stream.getvalue(), text)
+
+    def test_multiline_value_with_period(self):
+        text = (
+            "key:\n"
+            " longer\n"
+            " ..\n"
+            " value\n\n"
+        )
+        with StringIO() as stream:
+            RFC822Record({'key': 'longer\n.\nvalue'}).dump(stream)
+            self.assertEqual(stream.getvalue(), text)
+
+    def test_type_error(self):
+        with StringIO() as stream:
+            with self.assertRaises(AttributeError):
+                RFC822Record(['key', 'value']).dump(stream)
+
+
+class RFC822SyntaxErrorTests(TestCase):
+
+    """Tests for RFC822SyntaxError class."""
+
+    def test_hash(self):
+        """verify that RFC822SyntaxError is hashable."""
+        self.assertEqual(
+            hash(RFC822SyntaxError("file.txt", 10, "msg")),
+            hash(RFC822SyntaxError("file.txt", 10, "msg")))
+
+
+class UnknownTextSourceTests(TestCase):
+
+    """Tests for UnknownTextSource class."""
+
+    def setUp(self):
+        self.src = UnknownTextSource()
+
+    def test_str(self):
+        """verify how UnknownTextSource. __str__() works."""
+        self.assertEqual(str(self.src), "???")
+
+    def test_repr(self):
+        """verify how UnknownTextSource.__repr__() works."""
+        self.assertEqual(repr(self.src), "UnknownTextSource()")
+
+    def test_eq(self):
+        """
+        verify instances of UnknownTextSource are all equal to each other
+        but not equal to any other object
+        """
+        other_src = UnknownTextSource()
+        self.assertTrue(self.src == other_src)
+        self.assertFalse(self.src == "???")
+
+    def test_eq_others(self):
+        """
+        verify instances of UnknownTextSource are unequal to instances of other
+        classes
+        """
+        self.assertTrue(self.src != object())
+        self.assertFalse(self.src == object())
+
+    def test_gt(self):
+        """verify that instances of UnknownTextSource are not ordered."""
+        other_src = UnknownTextSource()
+        self.assertFalse(self.src < other_src)
+        self.assertFalse(other_src < self.src)
+
+    def test_gt_others(self):
+        """
+        verify that instances of UnknownTextSource are not comparable to other
+        objects
+        """
+        with self.assertRaises(TypeError):
+            self.src < object()
+        with self.assertRaises(TypeError):
+            object() < self.src
+
+
+class FileTextSourceTests(TestCase):
+
+    """Tests for FileTextSource class."""
+
+    _FILENAME = "filename"
+    _CLS = FileTextSource
+
+    def setUp(self):
+        self.src = self._CLS(self._FILENAME)
+
+    def test_filename(self):
+        """verify that FileTextSource.filename works."""
+        self.assertEqual(self._FILENAME, self.src.filename)
+
+    def test_str(self):
+        """verify that FileTextSource.__str__() works."""
+        self.assertEqual(str(self.src), self._FILENAME)
+
+    def test_repr(self):
+        """verify that FileTextSource.__repr__() works."""
+        self.assertEqual(
+            repr(self.src),
+            "{}({!r})".format(self._CLS.__name__, self._FILENAME))
+
+    def test_eq(self):
+        """
+        verify that FileTextSource compares equal to other instances with the
+        same filename and unequal to instances with different filenames.
+        """
+        self.assertTrue(self._CLS('foo') == self._CLS('foo'))
+        self.assertTrue(self._CLS('foo') != self._CLS('bar'))
+
+    def test_eq_others(self):
+        """
+        verify instances of FileTextSource are not equal to instances of other
+        classes
+        """
+        self.assertTrue(self._CLS('foo') != object())
+        self.assertFalse(self._CLS('foo') == object())
+
+    def test_gt(self):
+        """verify that FileTextSource is ordered by filename."""
+        self.assertTrue(self._CLS("a") < self._CLS("b") < self._CLS("c"))
+        self.assertTrue(self._CLS("c") > self._CLS("b") > self._CLS("a"))
+
+    def test_gt_others(self):
+        """
+        verify that instances of FileTextSource are not comparable to other
+        objects
+        """
+        with self.assertRaises(TypeError):
+            self.src < object()
+        with self.assertRaises(TypeError):
+            object() < self.src
+
+    def test_relative_to(self):
+        """verify that FileTextSource.relative_to() works."""
+        self.assertEqual(
+            self._CLS("/path/to/file.txt").relative_to("/path/to"),
+            self._CLS("file.txt"))
+
+
+class OriginTests(TestCase):
+
+    """Tests for Origin class."""
+
+    def setUp(self):
+        self.origin = Origin(FileTextSource("file.txt"), 10, 12)
+
+    def test_smoke(self):
+        """
+        verify that all three instance attributes actually work
+        """
+        self.assertEqual(self.origin.source.filename, "file.txt")
+        self.assertEqual(self.origin.line_start, 10)
+        self.assertEqual(self.origin.line_end, 12)
+
+    def test_repr(self):
+        """
+        verify that Origin.__repr__() works
+        """
+        expected = ("<Origin source:FileTextSource('file.txt')"
+                    " line_start:10 line_end:12>")
+        observed = repr(self.origin)
+        self.assertEqual(expected, observed)
+
+    def test_str(self):
+        """
+        verify that Origin.__str__() works
+        """
+        expected = "file.txt:10-12"
+        observed = str(self.origin)
+        self.assertEqual(expected, observed)
+
+    def test_str__single_line(self):
+        """
+        verify that Origin.__str__() behaves differently when the range
+        describes a single line
+        """
+        expected = "file.txt:15"
+        observed = str(Origin(FileTextSource("file.txt"), 15, 15))
+        self.assertEqual(expected, observed)
+
+    def test_str__whole_file(self):
+        """
+        verify that Origin.__str__() behaves differently when the range
+        is empty
+        """
+        expected = "file.txt"
+        observed = str(Origin(FileTextSource("file.txt")))
+        self.assertEqual(expected, observed)
+
+    def test_eq(self):
+        """
+        verify instances of Origin are all equal to other instances with the
+        same instance attributes but not equal to instances with different
+        attributes
+        """
+        origin1 = Origin(
+            self.origin.source, self.origin.line_start, self.origin.line_end)
+        origin2 = Origin(
+            self.origin.source, self.origin.line_start, self.origin.line_end)
+        self.assertTrue(origin1 == origin2)
+        origin_other1 = Origin(
+            self.origin.source, self.origin.line_start + 1,
+            self.origin.line_end)
+        self.assertTrue(origin1 != origin_other1)
+        self.assertFalse(origin1 == origin_other1)
+        origin_other2 = Origin(
+            self.origin.source, self.origin.line_start,
+            self.origin.line_end + 1)
+        self.assertTrue(origin1 != origin_other2)
+        self.assertFalse(origin1 == origin_other2)
+        origin_other3 = Origin(
+            FileTextSource("unrelated"), self.origin.line_start,
+            self.origin.line_end)
+        self.assertTrue(origin1 != origin_other3)
+        self.assertFalse(origin1 == origin_other3)
+
+    def test_eq_other(self):
+        """
+        verify instances of UnknownTextSource are unequal to instances of other
+        classes
+        """
+        self.assertTrue(self.origin != object())
+        self.assertFalse(self.origin == object())
+
+    def test_gt(self):
+        """
+        verify that Origin instances are ordered by their constituting
+        components
+        """
+        self.assertTrue(
+            Origin(FileTextSource('file.txt'), 1, 1) <
+            Origin(FileTextSource('file.txt'), 1, 2) <
+            Origin(FileTextSource('file.txt'), 1, 3))
+        self.assertTrue(
+            Origin(FileTextSource('file.txt'), 1, 10) <
+            Origin(FileTextSource('file.txt'), 2, 10) <
+            Origin(FileTextSource('file.txt'), 3, 10))
+        self.assertTrue(
+            Origin(FileTextSource('file1.txt'), 1, 10) <
+            Origin(FileTextSource('file2.txt'), 1, 10) <
+            Origin(FileTextSource('file3.txt'), 1, 10))
+
+    def test_gt_other(self):
+        """
+        verify that Origin instances are not comparable to other objects
+        """
+        with self.assertRaises(TypeError):
+            self.origin < object()
+        with self.assertRaises(TypeError):
+            object() < self.origin
+
+    def test_relative_to(self):
+        """
+        verify how Origin.relative_to() works in various situations
+        """
+        # if the source does not have relative_to method, nothing is changed
+        origin = Origin(UnknownTextSource(), 1, 2)
+        self.assertIs(origin.relative_to("/some/path"), origin)
+        # otherwise the source is replaced and a new origin is returned
+        self.assertEqual(
+            Origin(
+                FileTextSource("/some/path/file.txt"), 1, 2
+            ).relative_to("/some/path"),
+            Origin(FileTextSource("file.txt"), 1, 2))
+
+    def test_with_offset(self):
+        """
+        verify how Origin.with_offset() works as expected
+        """
+        origin1 = Origin(UnknownTextSource(), 1, 2)
+        origin2 = origin1.with_offset(10)
+        self.assertEqual(origin2.line_start, 11)
+        self.assertEqual(origin2.line_end, 12)
+        self.assertIs(origin2.source, origin1.source)
+
+    def test_just_line(self):
+        """
+        verify how Origin.just_line() works as expected
+        """
+        origin1 = Origin(UnknownTextSource(), 1, 2)
+        origin2 = origin1.just_line()
+        self.assertEqual(origin2.line_start, origin1.line_start)
+        self.assertEqual(origin2.line_end, origin1.line_start)
+        self.assertIs(origin2.source, origin1.source)
+
+    def test_just_file(self):
+        """
+        verify how Origin.just_file() works as expected
+        """
+        origin1 = Origin(UnknownTextSource(), 1, 2)
+        origin2 = origin1.just_file()
+        self.assertEqual(origin2.line_start, None)
+        self.assertEqual(origin2.line_end, None)
+        self.assertIs(origin2.source, origin1.source)


### PR DESCRIPTION
This branch adds crude support for loading and parsing assertions, specifically, the model assertion.

The parsing code is highly temporary as it is expected that next week snappy will provide first class
assertion parsing and validation command that we will switch to instead. In the meantime this is
sufficient for working with hand-made model assertion.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
