### PR TITLE
Add borrowed code for store support from snapcraft

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,13 @@ Maintainer: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
 Build-Depends: debhelper (>= 9),
     dh-python,
     python3-all,
+    python3-progressbar,
+    python3-requests,
+    python3-requests-oauthlib,
+    python3-requests-toolbelt,
+    python3-responses,
     python3-setuptools,
+    python3-ssoclient,
 Standards-Version: 3.9.7
 Homepage: http://launchpad.net/ubuntu-image
 

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,18 @@ setup(
     description='construct snappy images out of a model assertion',
     author_email='snapcraft@lists.ubuntu.com',
     url='https://github.com/CanonicalLtd/ubuntu-image',
-    packages=['ubuntu_image'],
+    packages=['ubuntu_image', 'ubuntu_image.storeapi'],
     scripts=['ubuntu-image'],
-    install_requires=[],
+    install_requires=[
+        'progressbar',
+        'requests',
+        'requests-oauthlib',
+        'requests-toolbelt',
+        'ssoclient',
+    ],
+    tests_require=[
+        'responses',
+    ],
     test_suite='ubuntu_image',
     license='GPLv3',
     classifiers=(

--- a/ubuntu_image/storeapi/__init__.py
+++ b/ubuntu_image/storeapi/__init__.py
@@ -1,0 +1,5 @@
+from ubuntu_image.storeapi.channels import get_channels, update_channels  # noqa
+from ubuntu_image.storeapi.info import get_info  # noqa
+from ubuntu_image.storeapi._login import login  # noqa
+from ubuntu_image.storeapi._download import download  # noqa
+from ubuntu_image.storeapi._upload import upload  # noqa

--- a/ubuntu_image/storeapi/_download.py
+++ b/ubuntu_image/storeapi/_download.py
@@ -1,0 +1,67 @@
+import hashlib
+import json
+import logging
+import os
+
+from ubuntu_image.storeapi.common import get_oauth_session
+
+
+_STORE_SEARCH_URL = 'https://search.apps.ubuntu.com/api/v1/search'
+
+logger = logging.getLogger(__name__)
+
+
+def download(snap_name, channel, download_path, config, arch):
+    """Download snap from the store to download_path"""
+    session = get_oauth_session(config)
+    if session is None:
+        raise EnvironmentError(
+            'No valid credentials found. Have you run "ubuntu-image login"?')
+
+    # TODO add release header
+    session.headers.update({
+        'accept': 'application/hal+json',
+        'X-Ubuntu-Architecture': arch,
+        'X-Ubuntu-Release': '16',
+        'X-Ubuntu-Device-Channel': channel,
+    })
+    session.params = {
+        'q': 'package_name:"{}"'.format(snap_name),
+        'fields': 'download_url,anon_download_url,download_sha512',
+    }
+
+    logger.info('Getting details for {!r}'.format(snap_name))
+    search = session.get(_STORE_SEARCH_URL).content.decode('utf-8')
+    search_results = json.loads(search)
+    logger.debug('search results {!r}'.format(search_results))
+
+    pkg = search_results['_embedded']['clickindex:package']
+    if len(pkg) != 1:
+        raise EnvironmentError(
+            'Unexpected store result {!r}'.format(search_results))
+    download_url = pkg[0].get('anon_download_url', pkg[0]['download_url'])
+    download_sha = pkg[0].get('download_sha512')
+
+    if _is_downloaded(download_path, download_sha):
+        logger.info('Already downloaded {!r}'.format(snap_name))
+    else:
+        logger.info('Downloading {!r}'.format(snap_name))
+        download = session.get(download_url)
+        with open(download_path, 'wb') as f:
+            f.write(download.content)
+        if _is_downloaded(download_path, download_sha):
+            logger.info('Successfully downloaded {!r}'.format(snap_name))
+        else:
+            raise RuntimeError('Failed to download {!r}'.format(snap_name))
+
+
+def _is_downloaded(download_path, download_sha):
+    if not os.path.exists(download_path):
+        return False
+
+    file_sum = hashlib.sha512()
+    with open(download_path, 'rb') as f:
+        for file_chunk in iter(
+                lambda: f.read(file_sum.block_size * 128), b''):
+            file_sum.update(file_chunk)
+    return download_sha == file_sum.hexdigest()

--- a/ubuntu_image/storeapi/_login.py
+++ b/ubuntu_image/storeapi/_login.py
@@ -1,0 +1,40 @@
+import os
+
+from ssoclient.v2 import (
+    ApiException,
+    UnexpectedApiError,
+    V2ApiClient,
+)
+
+from ubuntu_image.storeapi.constants import UBUNTU_SSO_API_ROOT_URL
+
+
+def login(email, password, token_name, otp=''):
+    """Log in via the Ubuntu One SSO API.
+
+    If successful, returns the oauth token data.
+    """
+    result = {
+        'success': False,
+        'body': None,
+    }
+
+    api_endpoint = os.environ.get(
+        'UBUNTU_SSO_API_ROOT_URL', UBUNTU_SSO_API_ROOT_URL)
+    client = V2ApiClient(endpoint=api_endpoint)
+    data = {
+        'email': email,
+        'password': password,
+        'token_name': token_name,
+    }
+    if otp:
+        data['otp'] = otp
+    try:
+        response = client.login(data=data)
+        result['body'] = response
+        result['success'] = True
+    except ApiException as err:
+        result['body'] = err.body
+    except UnexpectedApiError as err:
+        result['body'] = err.json_body
+    return result

--- a/ubuntu_image/storeapi/_upload.py
+++ b/ubuntu_image/storeapi/_upload.py
@@ -1,0 +1,348 @@
+import functools
+import json
+import logging
+import os
+import time
+
+import requests
+from concurrent.futures import ThreadPoolExecutor
+from progressbar import (ProgressBar, Percentage, Bar, AnimatedMarker)
+from requests_toolbelt import (MultipartEncoder, MultipartEncoderMonitor)
+
+from ubuntu_image.storeapi.common import (
+    get_oauth_session,
+    retry,
+)
+from ubuntu_image.storeapi.compat import open, quote_plus, urljoin
+from ubuntu_image.storeapi.constants import (
+    UBUNTU_STORE_API_ROOT_URL,
+    UBUNTU_STORE_UPLOAD_ROOT_URL,
+    SCAN_STATUS_POLL_DELAY,
+    SCAN_STATUS_POLL_RETRIES,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _update_progress_bar(progress_bar, maximum_value, monitor):
+    if monitor.bytes_read <= maximum_value:
+        progress_bar.update(monitor.bytes_read)
+
+
+def upload(binary_filename, snap_name, metadata_filename='', metadata=None,
+           config=None):
+    """Create a new upload based on a snap package."""
+    # Print a newline so the progress bar has some breathing room.
+    print('')
+
+    data = upload_files(binary_filename, config=config)
+    success = data.get('success', False)
+    errors = data.get('errors', [])
+    if not success:
+        logger.info('Upload failed:\n\n%s\n', '\n'.join(errors))
+        return False
+
+    meta = read_metadata(metadata_filename)
+    meta.update(metadata or {})
+    result = upload_app(snap_name, data, metadata=meta, config=config)
+    success = result.get('success', False)
+    errors = result.get('errors', [])
+    app_url = result.get('application_url', '')
+    revision = result.get('revision')
+
+    # Print another newline to make sure the user sees the final result of the
+    # upload (success/failure).
+    print('')
+
+    if success:
+        message = 'Application uploaded successfully'
+        if revision:
+            message += ' (as revision {})'.format(revision)
+
+        logger.info(message)
+    else:
+        logger.info('Upload did not complete.')
+
+    if errors:
+        logger.info('Some errors were detected:\n\n%s\n',
+                    '\n'.join(str(error) for error in errors))
+
+    if app_url:
+        logger.info('Please check out the application at: %s\n',
+                    app_url)
+
+    return success
+
+
+def upload_files(binary_filename, config=None):
+    """Upload a binary file to the Store.
+
+    Submit a file to the Store upload service and return the
+    corresponding upload_id.
+    """
+    updown_url = os.environ.get('UBUNTU_STORE_UPLOAD_ROOT_URL',
+                                UBUNTU_STORE_UPLOAD_ROOT_URL)
+    unscanned_upload_url = urljoin(updown_url, 'unscanned-upload/')
+
+    result = {'success': False, 'errors': []}
+
+    session = get_oauth_session(config)
+    if session is None:
+        result['errors'] = [
+            'No valid credentials found. Have you run "ubuntu-image login"?']
+        return result
+
+    try:
+        binary_file_size = os.path.getsize(binary_filename)
+        binary_file = open(binary_filename, 'rb')
+        encoder = MultipartEncoder(
+            fields={
+                'binary': ('filename', binary_file, 'application/octet-stream')
+            }
+        )
+
+        # Create a progress bar that looks like: Uploading foo [==  ] 50%
+        progress_bar = ProgressBar(
+            widgets=['Uploading {} '.format(binary_filename),
+                     Bar(marker='=', left='[', right=']'), ' ', Percentage()],
+            maxval=os.path.getsize(binary_filename)).start()
+
+        # Create a monitor for this upload, so that progress can be displayed
+        monitor = MultipartEncoderMonitor(
+            encoder, functools.partial(_update_progress_bar, progress_bar,
+                                       binary_file_size))
+
+        # Begin upload
+        response = session.post(
+            unscanned_upload_url,
+            data=monitor, headers={'Content-Type': monitor.content_type})
+
+        # Make sure progress bar shows 100% complete
+        progress_bar.finish()
+
+        if response.ok:
+            response_data = response.json()
+            result.update({
+                'success': response_data.get('successful', True),
+                'upload_id': response_data['upload_id'],
+                'binary_filesize': os.path.getsize(binary_filename),
+                'source_uploaded': False,
+            })
+        else:
+            logger.error(
+                'There was an error uploading the package.\n'
+                'Reason: %s\n'
+                'Text: %s',
+                response.reason, response.text)
+            result['errors'] = [response.text]
+    except Exception as err:
+        logger.exception(
+            'An unexpected error was found while uploading files.')
+        result['errors'] = [str(err)]
+    finally:
+        # Close the open file
+        binary_file.close()
+
+    return result
+
+
+def read_metadata(metadata_filename):
+    """Return a dictionary of metadata as read from a json file."""
+    if metadata_filename:
+        with open(metadata_filename, 'r') as metadata_file:
+            # file is automatically closed by context manager
+            metadata = json.load(metadata_file)
+    else:
+        metadata = {}
+
+    return metadata
+
+
+def upload_app(name, upload_data, metadata=None, config=None):
+    """Request a new upload to be created for a given upload_id."""
+    upload_url = get_upload_url(name)
+
+    result = {'success': False, 'errors': [],
+              'application_url': '', 'revision': None}
+
+    session = get_oauth_session(config)
+    if session is None:
+        result['errors'] = [
+            'No valid credentials found. Have you run "ubuntu-image login"?']
+        return result
+
+    if metadata is None:
+        metadata = {}
+
+    try:
+        data = get_post_data(upload_data, metadata=metadata)
+        files = get_post_files(metadata=metadata)
+
+        result = _upload_files(session, upload_url, data, files, result)
+    except Exception as err:
+        logger.exception(
+            'There was an error uploading the application.')
+        result['errors'] = [str(err)]
+    finally:
+        # make sure to close any open files used for request
+        for fname, fd in files:
+            fd.close()
+
+    return result
+
+
+def _upload_files(session, upload_url, data, files, result):
+    response = session.post(upload_url, data=data, files=files)
+    if response.ok:
+        response_data = response.json()
+        status_url = response_data['status_url']
+
+        # This is just a waiting game, so we'll show an indeterminate
+        # AnimatedMarker for it.
+        progress_indicator = ProgressBar(
+            widgets=['Checking package status... ', AnimatedMarker()],
+            maxval=7).start()
+
+        # Execute the package scan in another thread so we can update the
+        # progress indicator.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(get_scan_data, session, status_url)
+
+            count = 0
+            while not future.done():
+                # Annoyingly, there doesn't seem to be a way to actually
+                # make a progress indicator that will go on forever, so we
+                # need to restart this one each time we reach the end of
+                # its animation.
+                if count >= 7:
+                    progress_indicator.start()
+                    count = 0
+
+                # Actually update the progress indicator
+                progress_indicator.update(count)
+                count += 1
+                time.sleep(0.15)
+
+            # Grab the results from the package scan
+            completed, data = future.result()
+
+        progress_indicator.finish()
+
+        if completed:
+            message = data.get('message', '')
+            if not message:
+                result['success'] = True
+                result['revision'] = data.get('revision')
+            else:
+                result['errors'] = [message]
+        else:
+            result['errors'] = [
+                'Package scan took too long.',
+            ]
+            status_web_url = response_data.get('web_status_url')
+            if status_web_url:
+                result['errors'].append(
+                    'Please check the status later at: {}.'.format(
+                        status_web_url),
+                )
+        result['application_url'] = data.get('application_url', '')
+    else:
+        logger.error(
+            'There was an error uploading the application.\n'
+            'Reason: {}\n'
+            'Text: {}'.format(response.reason, response.text))
+        result['errors'] = [response.text]
+    return result
+
+
+def get_upload_url(name):
+    """Return the url of the uploaded package."""
+    store_api_url = os.environ.get('UBUNTU_STORE_API_ROOT_URL',
+                                   UBUNTU_STORE_API_ROOT_URL)
+    upload_url = urljoin(store_api_url, 'click-package-upload/')
+    upload_url += "%s/" % quote_plus(name)
+    return upload_url
+
+
+def get_post_data(upload_data, metadata=None):
+    """Return the data to be posted in order to create the upload."""
+    data = {
+        'updown_id': upload_data['upload_id'],
+        'binary_filesize': upload_data['binary_filesize'],
+        'source_uploaded': upload_data['source_uploaded'],
+    }
+    data.update({
+        key: value
+        for (key, value) in metadata.items()
+        if key not in (
+            # make sure not to override upload_id, binary_filesize and
+            # source_uploaded
+            'upload_id', 'binary_filesize', 'source_uploaded',
+            # skip files as they will be added to the files argument
+            'icon_256', 'icon', 'screenshots',
+        )
+    })
+    return data
+
+
+def get_post_files(metadata=None):
+    """Return data about files to upload during the package upload request."""
+    files = []
+
+    icon = metadata.get('icon', metadata.get('icon_256', ''))
+    if icon:
+        icon_file = open(icon, 'rb')
+        files.append(('icon_256', icon_file))
+
+    screenshots = metadata.get('screenshots', [])
+    for screenshot in screenshots:
+        screenshot_file = open(screenshot, 'rb')
+        files.append(('screenshots', screenshot_file))
+
+    return files
+
+
+def is_scan_completed(response):
+    """Return True if the response indicates the scan process completed."""
+    if response is None:
+        # To cope with spurious connection failures lacking a proper response:
+        # either we'll retry and succeed or we fail for all retries and report
+        # an error.
+        return False
+    if response.ok:
+        return response.json().get('completed', False)
+    return False
+
+
+def get_scan_status(session, url):
+    try:
+        resp = session.get(url)
+        return resp
+    except (requests.ConnectionError, requests.HTTPError):
+        # Something went wrong and we couldn't acquire the status. Upper
+        # level (is_scan_completed) will deal with the None response
+        # meaning we don't know the status. This avoid a spurious
+        # connection error breaking an upload for a wrong reason.
+        return None
+
+
+def get_scan_data(session, status_url):
+    """Return metadata about the state of the upload scan process."""
+    # initial retry after 5 seconds
+    # linear backoff after that
+    # abort after 5 retries
+    @retry(terminator=is_scan_completed,
+           retries=SCAN_STATUS_POLL_RETRIES,
+           delay=SCAN_STATUS_POLL_DELAY,
+           backoff=1)
+    def get_status():
+        return get_scan_status(session, status_url)
+
+    response, aborted = get_status()
+
+    completed = False
+    data = {}
+    if not aborted:
+        completed = is_scan_completed(response)
+        data = response.json()
+    return completed, data

--- a/ubuntu_image/storeapi/channels.py
+++ b/ubuntu_image/storeapi/channels.py
@@ -1,0 +1,18 @@
+from ubuntu_image.storeapi.common import store_api_call
+
+
+def get_channels(session, package_name):
+    """Get current channels config for package through API."""
+    channels_endpoint = 'package-channels/%s/' % package_name
+    return store_api_call(channels_endpoint, session=session)
+
+
+def update_channels(session, package_name, data):
+    """Update current channels config for package through API."""
+    channels_endpoint = 'package-channels/%s/' % package_name
+    result = store_api_call(channels_endpoint, method='POST',
+                            data=data, session=session)
+    if result['success']:
+        result['errors'] = result['data']['errors']
+        result['data'] = result['data']['channels']
+    return result

--- a/ubuntu_image/storeapi/common.py
+++ b/ubuntu_image/storeapi/common.py
@@ -1,0 +1,116 @@
+from functools import wraps
+import json
+import os
+import time
+
+import requests
+from requests_oauthlib import OAuth1Session
+
+from ubuntu_image.storeapi.compat import urljoin
+from ubuntu_image.storeapi.constants import UBUNTU_STORE_API_ROOT_URL
+
+
+def get_oauth_session(config):
+    """Return a client configured to allow oauth signed requests."""
+    try:
+        session = OAuth1Session(
+            config['consumer_key'],
+            client_secret=config['consumer_secret'],
+            resource_owner_key=config['token_key'],
+            resource_owner_secret=config['token_secret'],
+            signature_method='PLAINTEXT',
+        )
+    except KeyError:
+        session = None
+    return session
+
+
+def store_api_call(path, session=None, method='GET', data=None):
+    """Issue a request for a particular endpoint of the MyApps API."""
+    result = {'success': False, 'errors': [], 'data': None}
+    if session is not None:
+        client = session
+    else:
+        client = requests
+
+    root_url = os.environ.get('UBUNTU_STORE_API_ROOT_URL',
+                              UBUNTU_STORE_API_ROOT_URL)
+    url = urljoin(root_url, path)
+    if method == 'GET':
+        response = client.get(url)
+    elif method == 'POST':
+        response = client.post(url, data=data and json.dumps(data) or None,
+                               headers={'Content-Type': 'application/json'})
+    else:
+        raise ValueError('Method {} not supported'.format(method))
+
+    if response.ok:
+        result['success'] = True
+        result['data'] = response.json()
+    else:
+        result['errors'] = [response.text]
+    return result
+
+
+def retry(terminator=None, retries=3, delay=3, backoff=2, logger=None):
+    """Decorate a function to automatically retry calling it on failure.
+
+    Arguments:
+        - terminator: this should be a callable that returns a boolean;
+          it is used to determine if the function call was successful
+          and the retry loop should be stopped
+        - retries: an integer specifying the maximum number of retries
+        - delay: initial number of seconds to wait for the first retry
+        - backoff: exponential factor to use to adapt the delay between
+          subsequent retries
+        - logger: logging.Logger instance to use for logging
+
+    The decorated function will return as soon as any of the following
+    conditions are met:
+
+        1. terminator evaluates function output as True
+        2. there are no more retries left
+
+    If the terminator callable is not provided, the function will be called
+    exactly once and will not be retried.
+
+    """
+    def decorated(func):
+        if retries != int(retries) or retries < 0:
+            raise ValueError(
+                'retries value must be a positive integer or zero')
+        if delay < 0:
+            raise ValueError('delay value must be positive')
+
+        if backoff != int(backoff) or backoff < 1:
+            raise ValueError('backoff value must be a positive integer')
+
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            return _wrapped_retry(
+                terminator, retries, delay, backoff, logger,
+                func, *args, **kwargs)
+
+        return wrapped
+    return decorated
+
+
+def _wrapped_retry(terminator, retries, delay, backoff, logger,
+                   func, *args, **kwargs):
+    retries_left, current_delay = retries, delay
+
+    result = func(*args, **kwargs)
+    if terminator is not None:
+        while not terminator(result) and retries_left > 0:
+            msg = "... retrying in %d seconds" % current_delay
+            if logger:
+                logger.warning(msg)
+
+            # sleep
+            time.sleep(current_delay)
+            retries_left -= 1
+            current_delay *= backoff
+            # retry
+            result = func(*args, **kwargs)
+
+    return result, retries_left == 0

--- a/ubuntu_image/storeapi/compat.py
+++ b/ubuntu_image/storeapi/compat.py
@@ -1,0 +1,7 @@
+try:  # pragma: no cover
+    from builtins import open  # noqa
+    from urllib.parse import quote_plus, urljoin
+except ImportError:  # pragma: no cover
+    from __builtin__ import open  # noqa
+    from urllib import quote_plus  # noqa
+    from urlparse import urljoin  # noqa

--- a/ubuntu_image/storeapi/constants.py
+++ b/ubuntu_image/storeapi/constants.py
@@ -1,0 +1,5 @@
+SCAN_STATUS_POLL_DELAY = 5
+SCAN_STATUS_POLL_RETRIES = 5
+UBUNTU_SSO_API_ROOT_URL = 'https://login.ubuntu.com/api/v2/'
+UBUNTU_STORE_API_ROOT_URL = 'https://myapps.developer.ubuntu.com/dev/api/'
+UBUNTU_STORE_UPLOAD_ROOT_URL = 'https://upload.apps.ubuntu.com/'

--- a/ubuntu_image/storeapi/info.py
+++ b/ubuntu_image/storeapi/info.py
@@ -1,0 +1,14 @@
+from ubuntu_image.storeapi.common import store_api_call
+
+
+def get_info():
+    """Return information about the MyApps API.
+
+    Returned data contains information about:
+    - version
+    - department
+    - license
+    - country
+    - channel
+    """
+    return store_api_call('')

--- a/ubuntu_image/storeapi/test_channels.py
+++ b/ubuntu_image/storeapi/test_channels.py
@@ -1,0 +1,140 @@
+import json
+from unittest import TestCase
+from unittest.mock import patch
+
+from ubuntu_image.storeapi.channels import get_channels, update_channels
+
+
+class ChannelsAPITestCase(TestCase):
+
+    def setUp(self):
+        super(ChannelsAPITestCase, self).setUp()
+
+        # setup patches
+        oauth_session = 'ubuntu_image.storeapi.common.get_oauth_session'
+        patcher = patch(oauth_session)
+        self.mock_get_oauth_session = patcher.start()
+        self.mock_session = self.mock_get_oauth_session.return_value
+        self.addCleanup(patcher.stop)
+
+        self.mock_get = self.mock_session.get
+        self.mock_post = self.mock_session.post
+
+        self.channels_data = [
+            {'channel': 'stable', 'current': {'revision': 2, 'version': '1'}},
+            {'channel': 'beta', 'current': {'revision': 4, 'version': '1.5'}},
+            {'channel': 'edge', 'current': None},
+        ]
+
+    def set_channels_get_success_response(self):
+        mock_response = self.mock_get.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = self.channels_data
+
+    def set_channels_get_error_response(self, error_msg):
+        mock_response = self.mock_get.return_value
+        mock_response.ok = False
+        mock_response.text = error_msg
+
+    def set_channels_post_success_response(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'success': True, 'errors': [], 'channels': self.channels_data
+        }
+
+    def set_channels_post_failed_response(self, error_msg):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'success': True, 'errors': [error_msg],
+            'channels': self.channels_data
+        }
+
+    def set_channels_post_error_response(self, error_msg):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = False
+        mock_response.text = error_msg
+
+    def test_get_channels(self):
+        self.set_channels_get_success_response()
+
+        data = get_channels(self.mock_session, 'package.name')
+
+        expected = {
+            'success': True,
+            'errors': [],
+            'data': self.channels_data,
+        }
+        self.assertEqual(data, expected)
+
+    def test_get_channels_with_error_response(self):
+        error_msg = 'some error'
+        self.set_channels_get_error_response(error_msg)
+
+        data = get_channels(self.mock_session, 'package.name')
+
+        expected = {
+            'success': False,
+            'errors': [error_msg],
+            'data': None,
+        }
+        self.assertEqual(data, expected)
+
+    def test_get_channels_uses_environment_variables(self):
+        with patch('ubuntu_image.storeapi.common.os.environ',
+                   {'UBUNTU_STORE_API_ROOT_URL': 'http://example.com'}):
+            get_channels(self.mock_session, 'package.name')
+        self.mock_get.assert_called_once_with(
+            'http://example.com/package-channels/package.name/')
+
+    def test_update_channels(self):
+        self.set_channels_post_success_response()
+
+        data = update_channels(
+            self.mock_session, 'package.name', {'stable': 2})
+
+        expected = {
+            'success': True,
+            'errors': [],
+            'data': self.channels_data,
+        }
+        self.assertEqual(data, expected)
+
+    def test_update_channels_with_error_response(self):
+        error_msg = 'some error'
+        self.set_channels_post_error_response(error_msg)
+
+        data = update_channels(
+            self.mock_session, 'package.name', {'stable': 2})
+
+        expected = {
+            'success': False,
+            'errors': [error_msg],
+            'data': None,
+        }
+        self.assertEqual(data, expected)
+
+    def test_update_channels_with_failed_response(self):
+        error_msg = 'some error'
+        self.set_channels_post_failed_response(error_msg)
+
+        data = update_channels(
+            self.mock_session, 'package.name', {'stable': 2})
+
+        expected = {
+            'success': True,
+            'errors': [error_msg],
+            'data': self.channels_data,
+        }
+        self.assertEqual(data, expected)
+
+    def test_update_channels_uses_environment_variables(self):
+        with patch('ubuntu_image.storeapi.common.os.environ',
+                   {'UBUNTU_STORE_API_ROOT_URL': 'http://example.com'}):
+            update_channels(
+                self.mock_session, 'package.name', {'stable': 2})
+        self.mock_post.assert_called_once_with(
+            'http://example.com/package-channels/package.name/',
+            data=json.dumps({'stable': 2}),
+            headers={'Content-Type': 'application/json'})

--- a/ubuntu_image/storeapi/test_common.py
+++ b/ubuntu_image/storeapi/test_common.py
@@ -1,0 +1,201 @@
+import json
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+import responses
+from requests_oauthlib import OAuth1Session
+
+from ubuntu_image.storeapi.common import (
+    get_oauth_session,
+    store_api_call,
+    retry,
+)
+
+
+class GetOAuthSessionTestCase(TestCase):
+
+    def test_get_oauth_session_when_no_config(self):
+        config = {}
+        session = get_oauth_session(config)
+        self.assertIsNone(session)
+
+    def test_get_oauth_session_when_partial_config(self):
+        config = {
+            'consumer_key': 'consumer-key',
+            'consumer_secret': 'consumer-secret',
+        }
+        session = get_oauth_session(config)
+        self.assertIsNone(session)
+
+    def test_get_oauth_session(self):
+        config = {
+            'consumer_key': 'consumer-key',
+            'consumer_secret': 'consumer-secret',
+            'token_key': 'token-key',
+            'token_secret': 'token-secret',
+        }
+        session = get_oauth_session(config)
+        self.assertIsInstance(session, OAuth1Session)
+        self.assertEqual(session.auth.client.client_key, 'consumer-key')
+        self.assertEqual(session.auth.client.client_secret, 'consumer-secret')
+        self.assertEqual(session.auth.client.resource_owner_key, 'token-key')
+        self.assertEqual(session.auth.client.resource_owner_secret,
+                         'token-secret')
+
+
+class ApiCallTestCase(TestCase):
+
+    def setUp(self):
+        super(ApiCallTestCase, self).setUp()
+        p = patch('ubuntu_image.storeapi.common.os')
+        mock_os = p.start()
+        self.addCleanup(p.stop)
+        mock_os.environ = {'UBUNTU_STORE_API_ROOT_URL': 'http://example.com'}
+
+    @responses.activate
+    def test_get_success(self):
+        response_data = {'response': 'value'}
+        responses.add(responses.GET, 'http://example.com/path',
+                      body=json.dumps(response_data))
+
+        result = store_api_call('/path')
+        self.assertEqual(result, {
+            'success': True,
+            'data': response_data,
+            'errors': [],
+        })
+
+    @responses.activate
+    def test_get_error(self):
+        response_data = {'response': 'error'}
+        responses.add(responses.GET, 'http://example.com/path',
+                      body=json.dumps(response_data), status=500)
+
+        result = store_api_call('/path')
+        self.assertEqual(result, {
+            'success': False,
+            'data': None,
+            'errors': [json.dumps(response_data)],
+        })
+
+    @responses.activate
+    def test_post_success(self):
+        response_data = {'response': 'value'}
+        responses.add(responses.POST, 'http://example.com/path',
+                      body=json.dumps(response_data))
+
+        result = store_api_call('/path', method='POST')
+        self.assertEqual(result, {
+            'success': True,
+            'data': response_data,
+            'errors': [],
+        })
+
+    @responses.activate
+    def test_post_error(self):
+        response_data = {'response': 'value'}
+        responses.add(responses.POST, 'http://example.com/path',
+                      body=json.dumps(response_data), status=500)
+
+        result = store_api_call('/path', method='POST')
+        self.assertEqual(result, {
+            'success': False,
+            'data': None,
+            'errors': [json.dumps(response_data)],
+        })
+
+    def test_unsupported_method(self):
+        self.assertRaises(ValueError, store_api_call, '/path', method='FOO')
+
+    def test_get_with_session(self):
+        session = Mock()
+        store_api_call('/path', session=session)
+        session.get.assert_called_once_with('http://example.com/path')
+
+    def test_post_with_session(self):
+        session = Mock()
+        store_api_call('/path', method='POST', session=session)
+        session.post.assert_called_once_with(
+            'http://example.com/path',
+            data=None, headers={'Content-Type': 'application/json'})
+
+    @responses.activate
+    def test_post_with_data(self):
+        response_data = {'response': 'value'}
+        responses.add(responses.POST, 'http://example.com/path',
+                      body=json.dumps(response_data))
+
+        result = store_api_call(
+            '/path', method='POST', data={'request': 'value'})
+        self.assertEqual(result, {
+            'success': True,
+            'data': response_data,
+            'errors': [],
+        })
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.headers['Content-Type'],
+                         'application/json')
+        self.assertEqual(responses.calls[0].request.body,
+                         json.dumps({'request': 'value'}))
+
+
+class RetryDecoratorTestCase(TestCase):
+
+    def target(self, *args, **kwargs):
+        return dict(args=args, kwargs=kwargs)
+
+    def test_retry(self):
+        result, aborted = retry()(self.target)()
+        self.assertEqual(result, dict(args=(), kwargs={}))
+        self.assertEqual(aborted, False)
+
+    @patch('ubuntu_image.storeapi.common.time.sleep')
+    def test_retry_small_backoff(self, mock_sleep):
+        mock_terminator = Mock()
+        mock_terminator.return_value = False
+
+        delay = 0.001
+        result, aborted = retry(mock_terminator, retries=2,
+                                delay=delay)(self.target)()
+
+        self.assertEqual(result, dict(args=(), kwargs={}))
+        self.assertEqual(aborted, True)
+        self.assertEqual(mock_terminator.call_count, 3)
+        self.assertEqual(mock_sleep.mock_calls, [
+            call(delay),
+            call(delay * 2),
+        ])
+
+    def test_retry_abort(self):
+        mock_terminator = Mock()
+        mock_terminator.return_value = False
+        mock_logger = Mock()
+
+        result, aborted = retry(mock_terminator, delay=0.001, backoff=1,
+                                logger=mock_logger)(self.target)()
+
+        self.assertEqual(result, dict(args=(), kwargs={}))
+        self.assertEqual(aborted, True)
+        self.assertEqual(mock_terminator.call_count, 4)
+        self.assertEqual(mock_logger.warning.call_count, 3)
+
+    def test_retry_with_invalid_retries(self):
+        for value in (0.1, -1):
+            with self.assertRaises(ValueError) as ctx:
+                retry(retries=value)(self.target)
+            self.assertEqual(
+                str(ctx.exception),
+                'retries value must be a positive integer or zero')
+
+    def test_retry_with_negative_delay(self):
+        with self.assertRaises(ValueError) as ctx:
+            retry(delay=-1)(self.target)
+        self.assertEqual(str(ctx.exception),
+                         'delay value must be positive')
+
+    def test_retry_with_invalid_backoff(self):
+        for value in (-1, 0, 0.1):
+            with self.assertRaises(ValueError) as ctx:
+                retry(backoff=value)(self.target)
+            self.assertEqual(str(ctx.exception),
+                             'backoff value must be a positive integer')

--- a/ubuntu_image/storeapi/test_download.py
+++ b/ubuntu_image/storeapi/test_download.py
@@ -1,0 +1,182 @@
+from unittest import TestCase
+from unittest.mock import call, patch
+import json
+import os
+import tempfile
+import shutil
+
+from requests import Response
+
+from ubuntu_image.storeapi._download import download
+
+
+class DownloadBaseTestCase(TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        # setup patches
+        patcher = patch('ubuntu_image.storeapi._download.get_oauth_session')
+        self.mock_get_oauth_session = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch('ubuntu_image.storeapi._download.logger')
+        self.mock_logger = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.mock_get = self.mock_get_oauth_session.return_value.get
+
+        old_dir = os.getcwd()
+        new_dir = tempfile.mkdtemp()
+        os.chdir(new_dir)
+        self.addCleanup(lambda: os.chdir(old_dir))
+        self.addCleanup(lambda: shutil.rmtree(new_dir))
+
+
+class DownloadTestCase(DownloadBaseTestCase):
+
+    def test_download_files_get_metadata_failed(self):
+        self.mock_get.side_effect = Exception('some error')
+
+        with self.assertRaises(Exception) as raised:
+            download('os', 'edge', 'os.snap', None, 'amd64')
+
+        self.assertEqual('some error', str(raised.exception))
+
+        self.mock_logger.info.assert_called_once_with(
+            "Getting details for 'os'")
+        self.assertFalse(os.path.exists('os.snap'))
+
+    def test_download(self):
+        snap_content = b'1234567890'
+        snap_sha512 = ('12b03226a6d8be9c6e8cd5e55dc6c7920caaa39df14aab92d5e'
+                       '3ea9340d1c8a4d3d0b8e4314f1f6ef131ba4bf1ceb9186ab87c'
+                       '801af0d5c95b1befb8cedae2b9')
+        mock_details = self.mock_get.return_value
+        mock_details.ok = True
+        mock_details.content = json.dumps({
+            '_embedded': {
+                    'clickindex:package': [{
+                        'download_url': 'http://localhost',
+                        'anon_download_url': 'http://localhost',
+                        'download_sha512': snap_sha512,
+                    }],
+            }
+        }).encode('utf-8')
+        mock_snap = Response()
+        mock_snap.status_code = 200
+        mock_snap._content = snap_content
+
+        self.mock_get.side_effect = [mock_details, mock_snap]
+
+        download('os', 'edge', 'os.snap', None, 'amd64')
+
+        self.mock_logger.info.assert_has_calls([
+            call("Getting details for 'os'"),
+            call("Downloading 'os'"),
+            call("Successfully downloaded 'os'")])
+        self.assertTrue(os.path.exists('os.snap'))
+
+    def test_download_redownload_as_hash_mismatches(self):
+        with open('os.snap', 'wb') as f:
+            f.write(b'0000000')
+
+        snap_content = b'1234567890'
+        snap_sha512 = ('12b03226a6d8be9c6e8cd5e55dc6c7920caaa39df14aab92d5e'
+                       '3ea9340d1c8a4d3d0b8e4314f1f6ef131ba4bf1ceb9186ab87c'
+                       '801af0d5c95b1befb8cedae2b9')
+        mock_details = self.mock_get.return_value
+        mock_details.ok = True
+        mock_details.content = json.dumps({
+            '_embedded': {
+                    'clickindex:package': [{
+                        'download_url': 'http://localhost',
+                        'anon_download_url': 'http://localhost',
+                        'download_sha512': snap_sha512,
+                    }],
+            }
+        }).encode('utf-8')
+        mock_snap = Response()
+        mock_snap.status_code = 200
+        mock_snap._content = snap_content
+
+        self.mock_get.side_effect = [mock_details, mock_snap]
+
+        download('os', 'edge', 'os.snap', None, 'amd64')
+
+        self.mock_logger.info.assert_has_calls([
+            call("Getting details for 'os'"),
+            call("Downloading 'os'"),
+            call("Successfully downloaded 'os'")])
+        self.assertTrue(os.path.exists('os.snap'))
+
+    def test_download_fails_due_to_hash_mismatch(self):
+        snap_content = b'1234567890'
+        mock_details = self.mock_get.return_value
+        mock_details.ok = True
+        mock_details.content = json.dumps({
+            '_embedded': {
+                    'clickindex:package': [{
+                        'download_url': 'http://localhost',
+                        'anon_download_url': 'http://localhost',
+                        'download_sha512': '12345',
+                    }],
+            }
+        }).encode('utf-8')
+        mock_snap = Response()
+        mock_snap.status_code = 200
+        mock_snap._content = snap_content
+
+        self.mock_get.side_effect = [mock_details, mock_snap]
+
+        with self.assertRaises(RuntimeError) as raised:
+            download('os', 'edge', 'os.snap', None, 'amd64')
+
+        self.assertEqual("Failed to download 'os'", str(raised.exception))
+        self.mock_logger.info.assert_has_calls([
+            call("Getting details for 'os'"),
+            call("Downloading 'os'")])
+        self.assertTrue(os.path.exists('os.snap'))
+
+    def test_snap_already_downloaded(self):
+        snap_content = b'1234567890'
+        snap_sha512 = ('12b03226a6d8be9c6e8cd5e55dc6c7920caaa39df14aab92d5e'
+                       '3ea9340d1c8a4d3d0b8e4314f1f6ef131ba4bf1ceb9186ab87c'
+                       '801af0d5c95b1befb8cedae2b9')
+
+        with open('os.snap', 'wb') as f:
+            f.write(snap_content)
+
+        mock_details = self.mock_get.return_value
+        mock_details.ok = True
+        mock_details.content = json.dumps({
+            '_embedded': {
+                    'clickindex:package': [{
+                        'download_url': 'http://localhost',
+                        'anon_download_url': 'http://localhost',
+                        'download_sha512': snap_sha512,
+                    }],
+            }
+        }).encode('utf-8')
+        mock_snap = Response()
+        mock_snap.status_code = 200
+        mock_snap._content = snap_content
+
+        self.mock_get.side_effect = [mock_details, mock_snap]
+
+        download('os', 'edge', 'os.snap', None, 'amd64')
+
+        self.mock_logger.info.assert_has_calls([
+            call("Getting details for 'os'"),
+            call("Already downloaded 'os'")])
+        self.assertTrue(os.path.exists('os.snap'))
+
+    def test_download_fails_when_not_logged_in(self):
+        self.mock_get_oauth_session.return_value = None
+
+        with self.assertRaises(EnvironmentError) as raised:
+            download('os', 'edge', 'os.snap', None, 'amd64')
+
+        self.assertEqual(
+            'No valid credentials found. Have you run "ubuntu-image login"?',
+            str(raised.exception))

--- a/ubuntu_image/storeapi/test_info.py
+++ b/ubuntu_image/storeapi/test_info.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from ubuntu_image.storeapi.info import get_info
+
+
+class InfoAPITestCase(TestCase):
+
+    def setUp(self):
+        super(InfoAPITestCase, self).setUp()
+
+        patcher = patch('ubuntu_image.storeapi.common.requests.get')
+        self.mock_get = patcher.start()
+        self.mock_response = self.mock_get.return_value
+        self.addCleanup(patcher.stop)
+
+    def test_get_info(self):
+        expected = {
+            'success': True,
+            'errors': [],
+            'data': {'version': 1},
+        }
+        self.mock_response.ok = True
+        self.mock_response.json.return_value = {'version': 1}
+        data = get_info()
+        self.assertEqual(data, expected)
+
+    def test_get_info_with_error_response(self):
+        expected = {
+            'success': False,
+            'errors': ['some error'],
+            'data': None,
+        }
+        self.mock_response.ok = False
+        self.mock_response.text = 'some error'
+        data = get_info()
+        self.assertEqual(data, expected)
+
+    def test_get_info_uses_environment_variables(self):
+        with patch('ubuntu_image.storeapi.common.os.environ',
+                   {'UBUNTU_STORE_API_ROOT_URL': 'http://example.com'}):
+            get_info()
+        self.mock_get.assert_called_once_with('http://example.com')

--- a/ubuntu_image/storeapi/test_login.py
+++ b/ubuntu_image/storeapi/test_login.py
@@ -1,0 +1,122 @@
+from unittest import TestCase
+from unittest.mock import patch
+import json
+
+from requests import Response
+
+from ubuntu_image.storeapi._login import login
+from ubuntu_image.storeapi.constants import UBUNTU_SSO_API_ROOT_URL
+
+
+class LoginAPITestCase(TestCase):
+
+    def setUp(self):
+        super(LoginAPITestCase, self).setUp()
+        self.email = 'user@domain.com'
+        self.password = 'password'
+        self.token_name = 'token-name'
+
+        # setup patches
+        mock_environ = {
+            'UBUNTU_SSO_API_ROOT_URL': UBUNTU_SSO_API_ROOT_URL,
+        }
+        patcher = patch('ubuntu_image.storeapi._login.os.environ',
+                        mock_environ)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch('ssoclient.v2.http.requests.Session.request')
+        self.mock_request = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.token_data = {
+            'consumer_key': 'consumer-key',
+            'consumer_secret': 'consumer-secret',
+            'token_key': 'token-key',
+            'token_secret': 'token-secret',
+        }
+        response = self.make_response(status_code=201, reason='CREATED',
+                                      data=self.token_data)
+        self.mock_request.return_value = response
+
+    def make_response(self, status_code=200, reason='OK', data=None):
+        data = data or {}
+        response = Response()
+        response.status_code = status_code
+        response.reason = reason
+        response._content = json.dumps(data).encode('utf-8')
+        return response
+
+    def assert_login_request(self, otp='', token_name=None):
+        if token_name is None:
+            token_name = self.token_name
+        data = {
+            'email': self.email,
+            'password': self.password,
+            'token_name': token_name
+        }
+        if otp:
+            data['otp'] = otp
+        self.mock_request.assert_called_once_with(
+            'POST', UBUNTU_SSO_API_ROOT_URL + 'tokens/oauth',
+            data=json.dumps(data),
+            json=None, headers={'Content-Type': 'application/json'}
+        )
+
+    def test_login_successful(self):
+        result = login(self.email, self.password, self.token_name)
+        expected = {'success': True, 'body': self.token_data}
+        self.assertEqual(result, expected)
+        self.assert_login_request()
+
+    def test_default_token_name(self):
+        result = login(self.email, self.password, self.token_name)
+        expected = {'success': True, 'body': self.token_data}
+        self.assertEqual(result, expected)
+        self.assert_login_request()
+
+    def test_custom_token_name(self):
+        result = login(self.email, self.password, token_name='my-token')
+        expected = {'success': True, 'body': self.token_data}
+        self.assertEqual(result, expected)
+        self.assert_login_request(token_name='my-token')
+
+    def test_login_with_otp(self):
+        result = login(self.email, self.password, self.token_name,
+                       otp='123456')
+        expected = {'success': True, 'body': self.token_data}
+        self.assertEqual(result, expected)
+        self.assert_login_request(otp='123456')
+
+    def test_login_with_empty_otp_omits_it_from_request(self):
+        result = login(self.email, self.password, self.token_name, otp='')
+        expected = {'success': True, 'body': self.token_data}
+        self.assertEqual(result, expected)
+        self.assert_login_request()
+
+    def test_login_unsuccessful_api_exception(self):
+        error_data = {
+            'message': 'Error during login.',
+            'code': 'INVALID_CREDENTIALS',
+            'extra': {},
+        }
+        response = self.make_response(
+            status_code=401, reason='UNAUTHORISED', data=error_data)
+        self.mock_request.return_value = response
+
+        result = login(self.email, self.password, self.token_name)
+        expected = {'success': False, 'body': error_data}
+        self.assertEqual(result, expected)
+
+    def test_login_unsuccessful_unexpected_error(self):
+        error_data = {
+            'message': 'Error during login.',
+            'code': 'UNEXPECTED_ERROR_CODE',
+            'extra': {},
+        }
+        response = self.make_response(
+            status_code=401, reason='UNAUTHORISED', data=error_data)
+        self.mock_request.return_value = response
+
+        result = login(self.email, self.password, self.token_name)
+        expected = {'success': False, 'body': error_data}
+        self.assertEqual(result, expected)

--- a/ubuntu_image/storeapi/test_upload.py
+++ b/ubuntu_image/storeapi/test_upload.py
@@ -1,0 +1,669 @@
+from unittest.mock import ANY, call, patch
+import json
+import os
+import tempfile
+import unittest
+
+from requests import (
+    ConnectionError,
+    HTTPError,
+    Response,
+)
+
+from ubuntu_image.storeapi._upload import (
+    get_upload_url,
+    get_scan_status,
+    is_scan_completed,
+    upload_app,
+    upload_files,
+    upload,
+)
+
+
+class UploadBaseTestCase(unittest.TestCase):
+
+    def setUp(self):
+        super(UploadBaseTestCase, self).setUp()
+
+        # setup patches
+        name = 'ubuntu_image.storeapi._upload.get_oauth_session'
+        patcher = patch(name)
+        self.mock_get_oauth_session = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch('ubuntu_image.storeapi._upload.logger')
+        self.mock_logger = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch('sys.stdout')
+        self.mock_stdout = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.mock_get = self.mock_get_oauth_session.return_value.get
+        self.mock_post = self.mock_get_oauth_session.return_value.post
+
+        patcher = patch('ubuntu_image.storeapi._upload.ProgressBar')
+        self.mock_progressbar = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.suffix = '_0.1_all.snap'
+        self.binary_file = self.get_temporary_file(suffix=self.suffix)
+        with open(self.binary_file.name, 'w') as f:
+            f.write('bytes')
+
+        self.binary_file_size = os.path.getsize(self.binary_file.name)
+
+    def get_temporary_file(self, suffix='.cfg'):
+        return tempfile.NamedTemporaryFile(suffix=suffix)
+
+
+class UploadTestCase(UploadBaseTestCase):
+
+    def test_upload_files_failed(self):
+        self.mock_post.side_effect = Exception('some error')
+
+        success = upload(self.binary_file.name, 'foo')
+
+        self.assertFalse(success)
+        self.mock_logger.info.assert_called_once_with(
+            'Upload failed:\n\n%s\n', 'some error')
+
+    def test_upload_app_ok(self):
+        # fake upload response
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/',
+        }
+        # fake poll status response
+        application_url = 'http://example.com/app/1'
+        revision = '1'
+        ok_response = Response()
+        ok_response.status_code = 200
+        ok_response.encoding = 'utf-8'
+        ok_response._content = json.dumps(
+            {'completed': True, 'revision': revision,
+             'application_url': application_url}).encode('utf-8')
+        self.mock_get.return_value = ok_response
+
+        success = upload(self.binary_file.name, 'foo')
+
+        self.assertTrue(success)
+        self.assertIn(
+            call('Application uploaded successfully (as revision {})'.format(
+                revision)),
+            self.mock_logger.info.call_args_list)
+        self.assertIn(call('Please check out the application at: %s\n',
+                           application_url),
+                      self.mock_logger.info.call_args_list)
+
+    def test_upload_app_ok_without_revision(self):
+        # fake upload response
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/',
+        }
+        # fake poll status response
+        ok_response = Response()
+        ok_response.status_code = 200
+        ok_response.encoding = 'utf-8'
+        ok_response._content = json.dumps(
+            {'completed': True}).encode('utf-8')
+        self.mock_get.return_value = ok_response
+
+        success = upload(self.binary_file.name, 'foo')
+
+        self.assertTrue(success)
+        self.assertNotIn(
+            call('Uploaded as revision %s.', ANY),
+            self.mock_logger.info.call_args_list)
+
+    def test_upload_app_failed(self):
+        # fake upload response
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/',
+        }
+        # file uploaded ok, application submission failed
+        self.mock_post.side_effect = [mock_response, Exception('some error')]
+
+        success = upload(self.binary_file.name, 'foo')
+
+        self.assertFalse(success)
+        self.assertIn(
+            call('Upload did not complete.'),
+            self.mock_logger.info.call_args_list)
+        self.assertIn(
+            call('Some errors were detected:\n\n%s\n',
+                 'some error'),
+            self.mock_logger.info.call_args_list)
+
+
+class UploadWithScanTestCase(UploadBaseTestCase):
+
+    def test_default_metadata(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'successful': True,
+            'upload_id': 'some-valid-upload-id',
+        }
+
+        upload(self.binary_file.name, 'foo')
+
+        data = {
+            'updown_id': 'some-valid-upload-id',
+            'source_uploaded': False,
+            'binary_filesize': self.binary_file_size,
+        }
+
+        self.mock_post.assert_called_with(
+            get_upload_url('foo'), data=data, files=[])
+
+    def test_metadata_from_file(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'successful': True,
+            'upload_id': 'some-valid-upload-id',
+        }
+
+        with self.get_temporary_file() as metadata_file:
+            data = json.dumps({'name': 'from_file'})
+            metadata_file.write(data.encode('utf-8'))
+            metadata_file.flush()
+
+            upload(
+                self.binary_file.name, 'foo',
+                metadata_filename=metadata_file.name)
+
+        data = {
+            'updown_id': 'some-valid-upload-id',
+            'source_uploaded': False,
+            'binary_filesize': self.binary_file_size,
+            'name': 'from_file',
+        }
+
+        self.mock_post.assert_called_with(
+            get_upload_url('foo'), data=data, files=[])
+
+    def test_override_metadata(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'successful': True,
+            'upload_id': 'some-valid-upload-id',
+        }
+
+        upload(
+            self.binary_file.name, 'foo',
+            metadata={'name': 'overridden'})
+
+        data = {
+            'updown_id': 'some-valid-upload-id',
+            'source_uploaded': False,
+            'binary_filesize': self.binary_file_size,
+            'name': 'overridden',
+        }
+
+        self.mock_post.assert_called_with(
+            get_upload_url('foo'), data=data, files=[])
+
+
+class UploadFilesTestCase(UploadBaseTestCase):
+
+    def setUp(self):
+        super(UploadFilesTestCase, self).setUp()
+
+    def test_upload_files(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'successful': True,
+            'upload_id': 'some-valid-upload-id',
+        }
+
+        response = upload_files(self.binary_file.name)
+        self.assertEqual(response, {
+            'success': True,
+            'errors': [],
+            'upload_id': 'some-valid-upload-id',
+            'binary_filesize': self.binary_file_size,
+            'source_uploaded': False,
+        })
+
+        self.mock_progressbar.assert_called_once_with(
+            maxval=self.binary_file_size,
+            widgets=['Uploading {} '.format(self.binary_file.name), ANY, ' ',
+                     ANY])
+
+    def test_upload_files_uses_environment_variables(self):
+        with patch.dict(os.environ,
+                        UBUNTU_STORE_UPLOAD_ROOT_URL='http://example.com'):
+            upload_url = 'http://example.com/unscanned-upload/'
+            upload_files(self.binary_file.name)
+            self.mock_post.assert_called_once_with(
+                upload_url, data=ANY, headers={'Content-Type': ANY})
+
+        self.mock_progressbar.assert_called_once_with(
+            maxval=self.binary_file_size,
+            widgets=['Uploading {} '.format(self.binary_file.name), ANY, ' ',
+                     ANY])
+
+    def test_upload_files_with_source_upload(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'successful': True,
+            'upload_id': 'some-valid-upload-id',
+        }
+
+        response = upload_files(self.binary_file.name)
+        self.assertEqual(response, {
+            'success': True,
+            'errors': [],
+            'upload_id': 'some-valid-upload-id',
+            'binary_filesize': os.path.getsize(self.binary_file.name),
+            'source_uploaded': False,
+        })
+
+        self.mock_progressbar.assert_called_once_with(
+            maxval=self.binary_file_size,
+            widgets=['Uploading {} '.format(self.binary_file.name), ANY, ' ',
+                     ANY])
+
+    def test_upload_files_with_invalid_oauth_session(self):
+        self.mock_get_oauth_session.return_value = None
+        response = upload_files(self.binary_file.name)
+        self.assertEqual(response, {
+            'success': False,
+            'errors': [
+                ('No valid credentials found. Have you run'
+                 ' "ubuntu-image login"?')
+            ],
+        })
+        self.assertFalse(self.mock_post.called)
+        self.assertFalse(self.mock_progressbar.called)
+
+    def test_upload_files_error_response(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = False
+        mock_response.reason = '500 INTERNAL SERVER ERROR'
+        mock_response.text = 'server failed'
+
+        response = upload_files(self.binary_file.name)
+        self.assertEqual(response, {
+            'success': False,
+            'errors': ['server failed'],
+        })
+
+        self.mock_progressbar.assert_called_once_with(
+            maxval=self.binary_file_size,
+            widgets=['Uploading {} '.format(self.binary_file.name), ANY, ' ',
+                     ANY])
+
+    def test_upload_files_handle_malformed_response(self):
+        mock_response = self.mock_post.return_value
+        mock_response.json.return_value = {'successful': False}
+
+        response = upload_files(self.binary_file.name)
+        err = KeyError('upload_id')
+        self.assertEqual(response, {
+            'success': False,
+            'errors': [str(err)],
+        })
+
+        self.mock_progressbar.assert_called_once_with(
+            maxval=self.binary_file_size,
+            widgets=['Uploading {} '.format(self.binary_file.name), ANY, ' ',
+                     ANY])
+
+
+class UploadAppTestCase(UploadBaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.data = {
+            'upload_id': 'some-valid-upload-id',
+            'binary_filesize': 123456,
+            'source_uploaded': False,
+        }
+        self.package_name = 'namespace.binary'
+
+        patcher = patch.multiple(
+            'ubuntu_image.storeapi._upload',
+            SCAN_STATUS_POLL_DELAY=0.0001)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_upload_app_with_invalid_oauth_session(self):
+        self.mock_get_oauth_session.return_value = None
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': False,
+            'errors': [
+                ('No valid credentials found. Have you run'
+                 ' "ubuntu-image login"?')
+            ],
+            'application_url': '',
+            'revision': None,
+        })
+
+    def test_upload_app_uses_environment_variables(self):
+        with patch.dict(os.environ,
+                        UBUNTU_STORE_API_ROOT_URL='http://example.com'):
+            upload_url = ("http://example.com/click-package-upload/%s/" %
+                          self.package_name)
+            data = {
+                'updown_id': self.data['upload_id'],
+                'binary_filesize': self.data['binary_filesize'],
+                'source_uploaded': self.data['source_uploaded'],
+            }
+            upload_app(self.package_name, self.data)
+            self.mock_post.assert_called_once_with(
+                upload_url, data=data, files=[])
+
+    def test_upload_app(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/'
+        }
+
+        mock_status_response = self.mock_get.return_value
+        mock_status_response.ok = True
+        mock_status_response.json.return_value = {
+            'completed': True,
+            'revision': 15,
+        }
+
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': True,
+            'errors': [],
+            'application_url': '',
+            'revision': 15,
+        })
+
+    def test_upload_app_error_response(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = False
+        mock_response.reason = '500 INTERNAL SERVER ERROR'
+        mock_response.text = 'server failure'
+
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': False,
+            'errors': ['server failure'],
+            'application_url': '',
+            'revision': None,
+        })
+
+    def test_upload_app_handle_malformed_response(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {}
+
+        response = upload_app(self.package_name, self.data)
+        err = KeyError('status_url')
+        self.assertEqual(response, {
+            'success': False,
+            'errors': [str(err)],
+            'application_url': '',
+            'revision': None,
+        })
+
+    def test_upload_app_with_errors_during_scan(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/'
+        }
+
+        mock_status_response = self.mock_get.return_value
+        mock_status_response.ok = True
+        mock_status_response.json.return_value = {
+            'completed': True,
+            'message': 'some error',
+            'application_url': 'http://example.com/myapp',
+        }
+
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': False,
+            'errors': ['some error'],
+            'application_url': 'http://example.com/myapp',
+            'revision': None,
+        })
+
+    def test_upload_app_poll_status(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/'
+        }
+
+        response_not_completed = Response()
+        response_not_completed.status_code = 200
+        response_not_completed.encoding = 'utf-8'
+        response_not_completed._content = json.dumps(
+            {'completed': False, 'application_url': ''}).encode('utf-8')
+        response_completed = Response()
+        response_completed.status_code = 200
+        response_completed.encoding = 'utf-8'
+        response_completed._content = json.dumps(
+            {'completed': True, 'revision': 14,
+             'application_url': 'http://example.org'}).encode('utf-8')
+        self.mock_get.side_effect = [
+            response_not_completed,
+            response_not_completed,
+            response_completed,
+        ]
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': True,
+            'errors': [],
+            'application_url': 'http://example.org',
+            'revision': 14,
+        })
+        self.assertEqual(self.mock_get.call_count, 3)
+
+    def test_upload_app_ignore_non_ok_responses(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/',
+        }
+
+        ok_response = Response()
+        ok_response.status_code = 200
+        ok_response.encoding = 'utf-8'
+        ok_response._content = json.dumps(
+            {'completed': True, 'revision': 14}).encode('utf-8')
+        nok_response = Response()
+        nok_response.status_code = 503
+
+        self.mock_get.side_effect = [nok_response, nok_response, ok_response]
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': True,
+            'errors': [],
+            'application_url': '',
+            'revision': 14,
+        })
+        self.assertEqual(self.mock_get.call_count, 3)
+
+    def test_upload_app_abort_polling(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/',
+            'web_status_url': 'http://example.com/status-web/',
+        }
+
+        mock_status_response = self.mock_get.return_value
+        mock_status_response.ok = True
+        mock_status_response.json.return_value = {
+            'completed': False
+        }
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': False,
+            'errors': [
+                'Package scan took too long.',
+                'Please check the status later at: '
+                'http://example.com/status-web/.',
+            ],
+            'application_url': '',
+            'revision': None,
+        })
+
+    def test_upload_app_abort_polling_without_web_status_url(self):
+        mock_response = self.mock_post.return_value
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            'success': True,
+            'status_url': 'http://example.com/status/',
+        }
+
+        mock_status_response = self.mock_get.return_value
+        mock_status_response.ok = True
+        mock_status_response.json.return_value = {
+            'completed': False
+        }
+        response = upload_app(self.package_name, self.data)
+        self.assertEqual(response, {
+            'success': False,
+            'errors': [
+                'Package scan took too long.',
+            ],
+            'application_url': '',
+            'revision': None,
+        })
+
+    def test_upload_app_with_metadata(self):
+        upload_app(self.package_name, self.data, metadata={
+            'changelog': 'some changes', 'tagline': 'a tagline'})
+        self.mock_post.assert_called_once_with(
+            ANY,
+            data={
+                'updown_id': self.data['upload_id'],
+                'binary_filesize': self.data['binary_filesize'],
+                'source_uploaded': self.data['source_uploaded'],
+                'changelog': 'some changes',
+                'tagline': 'a tagline',
+            },
+            files=[],
+        )
+
+    def test_upload_app_ignore_special_attributes_in_metadata(self):
+        upload_app(
+            self.package_name,
+            self.data, metadata={
+                'changelog': 'some changes',
+                'tagline': 'a tagline',
+                'upload_id': 'my-own-id',
+                'binary_filesize': 0,
+                'source_uploaded': False,
+            })
+        self.mock_post.assert_called_once_with(
+            ANY,
+            data={
+                'updown_id': self.data['upload_id'],
+                'binary_filesize': self.data['binary_filesize'],
+                'source_uploaded': self.data['source_uploaded'],
+                'changelog': 'some changes',
+                'tagline': 'a tagline',
+            },
+            files=[],
+        )
+
+    @patch('ubuntu_image.storeapi._upload.open')
+    def test_upload_app_with_icon(self, mock_open):
+        with tempfile.NamedTemporaryFile() as icon:
+            mock_open.return_value = icon
+
+            upload_app(
+                self.package_name, self.data,
+                metadata={
+                    'icon_256': icon.name,
+                }
+            )
+            self.mock_post.assert_called_once_with(
+                ANY,
+                data={
+                    'updown_id': self.data['upload_id'],
+                    'binary_filesize': self.data['binary_filesize'],
+                    'source_uploaded': self.data['source_uploaded'],
+                },
+                files=[
+                    ('icon_256', icon),
+                ],
+            )
+
+    @patch('ubuntu_image.storeapi._upload.open')
+    def test_upload_app_with_screenshots(self, mock_open):
+        screenshot1 = tempfile.NamedTemporaryFile()
+        screenshot2 = tempfile.NamedTemporaryFile()
+        mock_open.side_effect = [screenshot1, screenshot2]
+
+        upload_app(
+            self.package_name, self.data,
+            metadata={
+                'screenshots': [screenshot1.name, screenshot2.name],
+            }
+        )
+        self.mock_post.assert_called_once_with(
+            ANY,
+            data={
+                'updown_id': self.data['upload_id'],
+                'binary_filesize': self.data['binary_filesize'],
+                'source_uploaded': self.data['source_uploaded'],
+            },
+            files=[
+                ('screenshots', screenshot1),
+                ('screenshots', screenshot2),
+            ],
+        )
+
+    def test_get_upload_url(self):
+        with patch.dict(os.environ,
+                        UBUNTU_STORE_API_ROOT_URL='http://example.com'):
+            upload_url = "http://example.com/click-package-upload/app.dev/"
+            url = get_upload_url('app.dev')
+            self.assertEqual(url, upload_url)
+
+
+class FakeSession(object):
+
+    def __init__(self, exc):
+        self.exc = exc
+
+    def get(self, url):
+        raise self.exc()
+
+
+class ScanStatusTestCase(unittest.TestCase):
+
+    def test_is_scan_complete_for_none(self):
+        self.assertFalse(is_scan_completed(None))
+
+    def get_scan_status(self, exc):
+        raiser = FakeSession(exc)
+        return get_scan_status(raiser, 'foo')
+
+    def test_get_status_connection_error(self):
+        self.assertIsNone(self.get_scan_status(ConnectionError))
+
+    def test_get_status_http_error(self):
+        self.assertIsNone(self.get_scan_status(HTTPError))


### PR DESCRIPTION
This patch brings in the storeapi package, copied from snapcraft with
minimal changes. The code brings in a number of new dependencies
(requests, requests-oauthlib, requests-toolbelt, ssoclient and
progressbar). Currently there is no CLI support for logging in, this
will be addressed in the next branch.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>