### PR TITLE
Add python3-debian to build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
 Build-Depends: debhelper (>= 9),
                dh-python,
                python3-all,
+               python3-debian,
                python3-progressbar,
                python3-requests,
                python3-requests-oauthlib,


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>