### PR TITLE
On Yakkety, flake8-respect-noqa is incompatible with flake8.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ commands =
     python -m flake8 ubuntu_image
 deps =
     flake8
-    flake8-respect-noqa
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
Remove it from tox.ini, but as I don't have a Xenial box handy at the moment, I'm submitting this PR to be sure the test suite still passes.