### PR TITLE
add snapcraft.yaml & --extra-snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: ubuntu-image
 summary: Create Ubuntu images
 description: |
   Use this tool to create Ubuntu images.
-version: 0.5
+version: 0.5+mvo1
 confinement: devmode
 
 apps:
@@ -23,3 +23,10 @@ parts:
       - usr
     stage-packages:
       - mtools
+  snapd:
+    plugin: go
+    source: https://github.com/snapcore/snapd
+    source-type: git
+    go-importpath: github.com/snapcore/snapd
+    snap:
+      - bin/snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: ubuntu-image
+summary: Create Ubuntu images
+description: |
+  Use this tool to create Ubuntu images.
+version: 0.4
+confinement: devmode
+
+apps:
+  ubuntu-image:
+    command: usr/bin/ubuntu-image
+
+parts:
+  ubuntu-image:
+    plugin: python3
+    source: https://github.com/mvo5/ubuntu-image.git
+    source-type: git
+    python-packages:
+      - python-debian
+      - attrs
+      - voluptuous
+      - PyYAML
+    snap:
+      - usr
+    stage-packages:
+      - mtools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: ubuntu-image
 summary: Create Ubuntu images
 description: |
   Use this tool to create Ubuntu images.
-version: 0.4
+version: 0.5
 confinement: devmode
 
 apps:

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -35,6 +35,11 @@ def parseargs(argv=None):
     parser.add_argument('-c', '--channel',
                         default=None,
                         help=_('For snap-based images, the channel to use'))
+    parser.add_argument('--extra-snaps',
+                        default=None,
+                        action='append',
+                        help=_("""For snap-based images, the extra snaps to
+                                  install"""))
     parser.add_argument('-w', '--workdir',
                         default=None,
                         help=_("""The working directory in which to download

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -135,7 +135,7 @@ class ModelAssertionBuilder(State):
         # Run `snap prepare-image` on the model.assertion.  sudo is currently
         # required in all cases, but eventually, it won't be necessary at
         # least for UEFI support.
-        snap(self.args.model_assertion, self.unpackdir, self.args.channel)
+        snap(self.args.model_assertion, self.unpackdir, self.args.channel, self.args.extra_snaps)
         self._next.append(self.load_gadget_yaml)
 
     def load_gadget_yaml(self):

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -322,7 +322,7 @@ class ModelAssertionBuilder(State):
                     for filename in os.listdir(part_dir)
                     )
                 run('mcopy -s -i {} {} ::'.format(part_img, sourcefiles),
-                    env=dict(MTOOLS_SKIP_CHECK='1'))
+                    env=dict(MTOOLS_SKIP_CHECK='1', PATH=os.environ["PATH"]))
             elif part.filesystem is FileSystemType.ext4:   # pragma: nocover
                 _mkfs_ext4(self.part_img, part_dir, part.filesystem_label)
         # The root partition needs to be ext4, which may or may not be

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -272,7 +272,11 @@ class ModelAssertionBuilder(State):
             run('dd if=/dev/zero of={} count=0 bs={} seek=1'.format(
                 part_img, part.size))
             if part.filesystem is FileSystemType.vfat:   # pragma: nobranch
-                run('mkfs.vfat {}'.format(part_img))
+                if part.filesystem_label:
+                    fslabel = "-n {}".format(part.filesystem_label)
+                else:
+                    fslabel = ""
+                run('mkfs.vfat {} {}'.format(fslabel, part_img))
             # XXX: Does not handle the case of partitions at the end of the
             # image.
             next_avail = part.offset + part.size

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -285,8 +285,10 @@ class ModelAssertionBuilder(State):
             raise AssertionError('No room for root filesystem data')
         self.rootfs_size = avail_space
         self.root_img = os.path.join(self.images, 'root.img')
-        run('dd if=/dev/zero of={} count=0 bs={}M seek=1'.format(
-            self.root_img, avail_space))
+        # create empty file with holes
+        with open(self.root_img,  "w"):
+            pass
+        os.truncate(self.root_img, avail_space * MiB(1))
         # We defer creating the root file system image because we have to
         # populate it at the same time.  See mkfs.ext4(8) for details.
         self._next.append(self.populate_filesystems)

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -94,9 +94,11 @@ def run(command, *, check=True, **args):
     runnable_command = (
         command.split() if 'shell' not in args
         else command)
+    stdout = args.pop("stdout", PIPE)
+    stderr = args.pop("stderr", PIPE)
     proc = subprocess_run(
         runnable_command,
-        stdout=PIPE, stderr=PIPE,
+        stdout=stdout, stderr=stderr,
         universal_newlines=True,
         **args)
     if check and proc.returncode != 0:
@@ -124,4 +126,4 @@ def snap(model_assertion, root_dir, channel=None, extra_snaps=None):   # pragma:
     # /usr/bin/squashfs.  This is currently unexplained.
     env = dict(UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL='1',
                PATH=os.environ["PATH"])
-    run(cmd, env=env)
+    run(cmd, env=env, stdout=None, stderr=None)

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -106,10 +106,12 @@ def run(command, *, check=True, **args):
     return proc
 
 
-def snap(model_assertion, root_dir, channel=None):   # pragma: notravis
-    raw_cmd = 'snap prepare-image {} {} {}'
+def snap(model_assertion, root_dir, channel=None, extra_snaps=None):   # pragma: notravis
+    raw_cmd = 'snap prepare-image {} {} {} {}'
     cmd = raw_cmd.format(
         '' if channel is None else '--channel={}'.format(channel),
+        '' if extra_snaps is None else " ".join(["--extra-snaps={}".format(e)
+                                                 for e in extra_snaps]),
         model_assertion,
         root_dir)
     # This environment variable is a temporary workaround to prevent `snap

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+import os
 
 from subprocess import PIPE, run as subprocess_run
 
@@ -122,5 +123,5 @@ def snap(model_assertion, root_dir, channel=None, extra_snaps=None):   # pragma:
     # $PATH is needed because without it `snap prepare-image` can't find
     # /usr/bin/squashfs.  This is currently unexplained.
     env = dict(UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL='1',
-               PATH='/usr/bin')
+               PATH=os.environ["PATH"])
     run(cmd, env=env)

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -110,8 +110,10 @@ def run(command, *, check=True, **args):
 
 
 def snap(model_assertion, root_dir, channel=None, extra_snaps=None):   # pragma: notravis
-    raw_cmd = 'snap prepare-image {} {} {} {}'
+    snap_cmd = os.environ.get("UBUNTU_IMAGE_SNAP_CMD", "snap")
+    raw_cmd = '{} prepare-image {} {} {} {}'
     cmd = raw_cmd.format(
+        snap_cmd,
         '' if channel is None else '--channel={}'.format(channel),
         '' if extra_snaps is None else " ".join(["--extra-snaps={}".format(e)
                                                  for e in extra_snaps]),

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -124,6 +124,6 @@ def snap(model_assertion, root_dir, channel=None, extra_snaps=None):   # pragma:
     #
     # $PATH is needed because without it `snap prepare-image` can't find
     # /usr/bin/squashfs.  This is currently unexplained.
-    env = dict(UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL='1',
-               PATH=os.environ["PATH"])
+    env = dict(UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL='1')
+    env.update(os.environ)
     run(cmd, env=env, stdout=None, stderr=None)

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -117,13 +117,6 @@ def snap(model_assertion, root_dir, channel=None, extra_snaps=None):   # pragma:
                                                  for e in extra_snaps]),
         model_assertion,
         root_dir)
-    # This environment variable is a temporary workaround to prevent `snap
-    # prepare-image` from failing with an unverified signature on the
-    # model.assertion.  We obviously can't sign it with the real root keys,
-    # and there's no other way to inject testing data.
-    #
-    # $PATH is needed because without it `snap prepare-image` can't find
-    # /usr/bin/squashfs.  This is currently unexplained.
-    env = dict(UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL='1')
-    env.update(os.environ)
-    run(cmd, env=env, stdout=None, stderr=None)
+    # Note that we do no longer hardcode the environment here.
+    # Set UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL=1 in the tests
+    run(cmd, stdout=None, stderr=None)


### PR DESCRIPTION
This adds a snapcraft.yaml file for ubuntu-image and fixes a bug where mcopy can not be found in the snap because the PATH is reset.

Note that the snap is not fully working because ubuntu-image when called without `sudo`. In this case the code tries to call sudo itself which will not work (yet) inside snaps because we have not the right pty available for the asking for a password.

Of couse you need to adjust the git path once its merged, I had to have this to be able to test the image.