### PR TITLE
Preseed cloud-init and allow further preseeding when building the image

### DIFF
--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -43,6 +43,9 @@ def parseargs(argv=None):
                         after this program exits.  If not given, a temporary
                         working directory is used instead, which *is* deleted
                         after this program exits."""))
+    parser.add_argument('--cloud-init',
+                        default=None,
+                        help=_("cloud-config data to be copied in the image"))
     parser.add_argument('-o', '--output',
                         default=None,
                         help=_('The output file for the disk image'))

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -157,7 +157,7 @@ class ModelAssertionBuilder(State):
         shutil.move(os.path.join(src, 'var'), os.path.join(dst, 'var'))
         seed_dir = os.path.join(dst, 'var', 'lib', 'cloud', 'seed')
         cloud_dir = os.path.join(seed_dir, 'nocloud-net')
-        os.makedirs(cloud_dir)
+        os.makedirs(cloud_dir, exist_ok=True)
         metadata_file = os.path.join(cloud_dir, 'meta-data')
         with open(metadata_file, 'w', encoding='utf-8') as f:
             print("instance-id: nocloud-static", file=f)

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -87,10 +87,7 @@ class ModelAssertionBuilder(State):
         self.gadget = None
         self.args = args
         self.unpackdir = None
-        self.cloud_init = (
-            None
-            if args.cloud_init is None
-            else args.cloud_init)
+        self.cloud_init = args.cloud_init
         self._next.append(self.make_temporary_directories)
 
     def __getstate__(self):
@@ -159,8 +156,8 @@ class ModelAssertionBuilder(State):
         cloud_dir = os.path.join(seed_dir, 'nocloud-net')
         os.makedirs(cloud_dir, exist_ok=True)
         metadata_file = os.path.join(cloud_dir, 'meta-data')
-        with open(metadata_file, 'w', encoding='utf-8') as f:
-            print("instance-id: nocloud-static", file=f)
+        with open(metadata_file, 'w', encoding='utf-8') as fp:
+            print('instance-id: nocloud-static', file=fp)
         if self.cloud_init is not None:
             userdata_file = os.path.join(cloud_dir, 'user-data')
             shutil.copy(self.cloud_init, userdata_file)

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -47,6 +47,7 @@ class TestModelAssertionBuilder(TestCase):
             workdir=None,
             output=output,
             model_assertion=self.model_assertion,
+            cloud_init=None,
             )
         state = self._resources.enter_context(XXXModelAssertionBuilder(args))
         state.run_thru('calculate_bootfs_size')
@@ -107,6 +108,7 @@ class TestModelAssertionBuilder(TestCase):
             workdir=None,
             model_assertion=self.model_assertion,
             output=None,
+            cloud_init=None,
             )
         with ExitStack() as resources:
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -129,6 +131,7 @@ class TestModelAssertionBuilder(TestCase):
             workdir=None,
             model_assertion=self.model_assertion,
             output=None,
+            cloud_init=None,
             )
         with ExitStack() as resources:
             state = resources.enter_context(XXXModelAssertionBuilder(args))


### PR DESCRIPTION
This passes the minimal instance-id value for cloud-init; and allows passing further preseed
config using '--cloud-init <file>' which should contain preseeding data for cloud-init and should
follow the documentation at:

https://git.launchpad.net/cloud-init/tree/doc/examples/cloud-config-user-groups.txt

Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>