### PR TITLE
preserve spare file when doing the final copy

### DIFF
--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -422,7 +422,8 @@ class ModelAssertionBuilder(State):
         self._next.append(self.finish)
 
     def finish(self):
-        # Move the completed disk image to destination location, since the
-        # temporary scratch directory is about to get removed.
-        shutil.move(self.disk_img, self.output)
+        # Copy the completed disk image to destination location, since the
+        # temporary scratch directory is about to get removed. Copy to
+        # ensure our sparse file remains sparse
+        run(["cp", "--sparse=always", self.disk_img, self.output])
         self._next.append(self.close)


### PR DESCRIPTION
A very crude workaround for the fact that the final copy will not preserve the sparse file when copying from /tmp to the final output. This is critical for the snap version of ubuntu-image because there /tmp is always a tmpfs so we always end up with a huge (not sparse) final output file.