### PR TITLE
Include e2fsprogs in the snapcraft stage packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: ubuntu-image
 summary: Create Ubuntu images
 description: |
   Use this tool to create Ubuntu images.
-version: 0.5+mvo1
+version: 0.5+mvo8
 confinement: devmode
 
 apps:
@@ -23,6 +23,7 @@ parts:
       - usr
     stage-packages:
       - mtools
+      - e2fsprogs
   snapd:
     plugin: go
     source: https://github.com/snapcore/snapd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,6 +21,7 @@ parts:
       - PyYAML
     snap:
       - usr
+      - sbin
     stage-packages:
       - mtools
       - e2fsprogs


### PR DESCRIPTION
This ensures that we have embedded mtools and e2fsprogs. When this is auto-build from launchpad inside a yakkety env we get a snap that does not need root to build images. LP builds for snaps with stage-packages seems to be broken currently so I build this manually on a yakkety chroot and pushed it to the store. Works for me .