### PR TITLE
Put options in some kind of sensible order in help output

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 ubuntu-image (0.7ubuntu1) UNRELEASED; urgency=medium
 
+  [ Steve Langasek ]
   * Don't build 4GB images, instead build images just as large as needed
     to hold the contents and let ubuntu-core resize them dynamically on
     first boot.  LP: #1619362.
@@ -8,6 +9,9 @@ ubuntu-image (0.7ubuntu1) UNRELEASED; urgency=medium
   * Declare Testsuite: autopkgtest-pkg-python in debian/control so that the
     package is visible to the test infrastructure.
   * Update model.assertion test file to be compatible with snapd 2.14.2.
+
+  [ Barry Warsaw ]
+  * Reorganize and flesh out command line options.
 
  -- Steve Langasek <steve.langasek@ubuntu.com>  Thu, 15 Sep 2016 04:06:30 +0000
 

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -47,14 +47,6 @@ def parseargs(argv=None):
         help=_("""The generated disk image file.  If not given, the image will
         be put in a file called disk.img in the working directory (in which
         case, you probably want to specify -w)."""))
-    common_group.add_argument(
-        '-w', '--workdir',
-        default=None, metavar='DIRECTORY',
-        help=_("""The working directory in which to download and unpack all
-        the source files for the image.  This directory can exist or not, and
-        it is not removed after this program exits.  If not given, a temporary
-        working directory is used instead, which *is* deleted after this
-        program exits."""))
     # Snap-based image options.
     snap_group = parser.add_argument_group(
         _('Image contents options'),
@@ -82,6 +74,15 @@ def parseargs(argv=None):
         case since the state is saved in a .ubuntu-image.pck file in the
         working directory."""))
     state_group = state_group.add_mutually_exclusive_group()
+    state_group.add_argument(
+        '-w', '--workdir',
+        default=None, metavar='DIRECTORY',
+        help=_("""The working directory in which to download and unpack all
+        the source files for the image.  This directory can exist or not, and
+        it is not removed after this program exits.  If not given, a temporary
+        working directory is used instead, which *is* deleted after this
+        program exits.  Use -w if you want to be able to resume a partial
+        state machine run."""))
     state_group.add_argument(
         '-u', '--until',
         default=None, metavar='STEP',

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -27,11 +27,10 @@ def parseargs(argv=None):
         prog=PROGRAM,
         description=_('Generate a bootable disk image.'),
         )
+    parser.add_argument('model_assertion', nargs='?',
+                        help=_('Path to the model assertion'))
     parser.add_argument('--version', action='version',
                         version='{} {}'.format(PROGRAM, __version__))
-    parser.add_argument('-d', '--debug',
-                        default=False, action='store_true',
-                        help=_('Enable debugging output'))
     parser.add_argument('-c', '--channel',
                         default=None,
                         help=_('For snap-based images, the channel to use'))
@@ -39,6 +38,15 @@ def parseargs(argv=None):
                         default=None, action='append',
                         help=_("""For snap-based images, the extra snaps to
                         install."""))
+    parser.add_argument('--cloud-init',
+                        default=None,
+                        help=_("cloud-config data to be copied in the image"))
+    parser.add_argument('-o', '--output',
+                        default=None,
+                        help=_('The output file for the disk image'))
+    parser.add_argument('-d', '--debug',
+                        default=False, action='store_true',
+                        help=_('Enable debugging output'))
     parser.add_argument('-w', '--workdir',
                         default=None,
                         help=_("""The working directory in which to download
@@ -47,19 +55,6 @@ def parseargs(argv=None):
                         after this program exits.  If not given, a temporary
                         working directory is used instead, which *is* deleted
                         after this program exits."""))
-    parser.add_argument('--cloud-init',
-                        default=None,
-                        help=_("cloud-config data to be copied in the image"))
-    parser.add_argument('-o', '--output',
-                        default=None,
-                        help=_('The output file for the disk image'))
-    parser.add_argument('-r', '--resume',
-                        default=False, action='store_true',
-                        help=_("""Continue the state machine from the
-                        previously saved state.  It is an error if there is no
-                        previous state."""))
-    parser.add_argument('model_assertion', nargs='?',
-                        help=_('Path to the model assertion'))
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-u', '--until',
                        default=None, metavar='STEP',
@@ -75,6 +70,11 @@ def parseargs(argv=None):
                        will be saved in a .ubuntu-image.pck file in the
                        working directory and can be resumed with -r.  Use -w
                        if you want to resume the process later."""))
+    parser.add_argument('-r', '--resume',
+                        default=False, action='store_true',
+                        help=_("""Continue the state machine from the
+                        previously saved state.  It is an error if there is no
+                        previous state."""))
     args = parser.parse_args(argv)
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -66,15 +66,14 @@ def parseargs(argv=None):
         default=None,
         help=_('The snap channel to use'))
     # State machine options.
-    state_group = parser.add_argument_group(
+    inclusive_state_group = parser.add_argument_group(
         _('State machine options'),
-        _("""Options for controlling the internal state machine.  These
-        options are mutually exclusive.  When -u or -t is given, the state
-        machine can be resumed later with -r, but -w must be given in that
-        case since the state is saved in a .ubuntu-image.pck file in the
+        _("""Options for controlling the internal state machine.  Other than
+        -w, these options are mutually exclusive.  When -u or -t is given, the
+        state machine can be resumed later with -r, but -w must be given in
+        that case since the state is saved in a .ubuntu-image.pck file in the
         working directory."""))
-    state_group = state_group.add_mutually_exclusive_group()
-    state_group.add_argument(
+    inclusive_state_group.add_argument(
         '-w', '--workdir',
         default=None, metavar='DIRECTORY',
         help=_("""The working directory in which to download and unpack all
@@ -83,6 +82,7 @@ def parseargs(argv=None):
         working directory is used instead, which *is* deleted after this
         program exits.  Use -w if you want to be able to resume a partial
         state machine run."""))
+    state_group = inclusive_state_group.add_mutually_exclusive_group()
     state_group.add_argument(
         '-u', '--until',
         default=None, metavar='STEP',


### PR DESCRIPTION
List common options first, debugging/developer options at the end