### PR TITLE
Trivial fixes in the helpers.py:run() env handling

### DIFF
--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -341,7 +341,7 @@ class ModelAssertionBuilder(State):
                     os.path.join(part_dir, filename)
                     for filename in os.listdir(part_dir)
                     )
-                env=dict(MTOOLS_SKIP_CHECK='1')
+                env = dict(MTOOLS_SKIP_CHECK='1')
                 env.update(os.environ)
                 run('mcopy -s -i {} {} ::'.format(part_img, sourcefiles),
                     env=env)

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -341,11 +341,10 @@ class ModelAssertionBuilder(State):
                     os.path.join(part_dir, filename)
                     for filename in os.listdir(part_dir)
                     )
-                # XXX Make sure the $PATH gets propagated to the mcopy(1)
-                # subprocess.  For unknown reasons it might not yet be set
-                # up.  See PR#46 for details.
+                env=dict(MTOOLS_SKIP_CHECK='1')
+                env.update(os.environ)
                 run('mcopy -s -i {} {} ::'.format(part_img, sourcefiles),
-                    env=dict(MTOOLS_SKIP_CHECK='1'))
+                    env=env)
             elif part.filesystem is FileSystemType.ext4:   # pragma: nocover
                 _mkfs_ext4(self.part_img, part_dir, part.filesystem_label)
         # The root partition needs to be ext4, which may or may not be

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -128,7 +128,7 @@ def snap(model_assertion, root_dir,
                          for extra in extra_snaps)),
         model_assertion,
         root_dir)
-    run(cmd, stdout=None, stderr=None, env=dict(PATH=os.environ['PATH']))
+    run(cmd, stdout=None, stderr=None)
 
 
 def sparse_copy(src, dst, *, follow_symlinks=True):


### PR DESCRIPTION
Per https://github.com/CanonicalLtd/ubuntu-image/pull/55, which this supersedes:

 See https://github.com/CanonicalLtd/ubuntu-image/pull/51/files#r77474300 for more details, essentially "run(..., env=env)" replaces the existing environment. However this is not what we want when using snaps because there are custom PATH and LD_LIBRARY_PATH setups.