### PR TITLE
Fix compatibility with older e2sprogs

### DIFF
--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -48,6 +48,9 @@ def _mkfs_ext4(img_file, contents_dir, label='writable'):
         # We have a new enough e2fsprogs, so we're done.
         return
     run('mkfs.ext4 -L {} {}'.format(label, img_file))  # pragma: notravis
+    # Only do this if the directory is non-empty.
+    if not os.listdir(contents_dir):
+        return
     with mount(img_file) as mountpoint:                # pragma: notravis
         # fixme: everything is terrible.
         run('sudo cp -dR --preserve=mode,timestamps {}/* {}'.format(

--- a/ubuntu_image/testing/nose.py
+++ b/ubuntu_image/testing/nose.py
@@ -41,7 +41,7 @@ def mock_run(command, *, check=True, **args):
     # can use our test data model.assertion, which obviously isn't signed.
     args.pop('stdout', None)
     args.pop('stderr', None)
-    env = args.setdefault('env', {})
+    env = args.setdefault('env', os.environ)
     env['UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL'] = '1'
     real_run(command, check=check, **args)
 


### PR DESCRIPTION
I'm not sure why 9f47500 wasn't already a general problem, I guess tests passed only because the snap tests are disabled in travis :/