### PR TITLE
include etc/ as well

### DIFF
--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -158,6 +158,7 @@ class ModelAssertionBuilder(State):
         src = os.path.join(self.unpackdir, 'image')
         dst = os.path.join(self.rootfs, 'system-data')
         shutil.move(os.path.join(src, 'var'), os.path.join(dst, 'var'))
+        shutil.move(os.path.join(src, 'etc'), os.path.join(dst, 'etc'))
         seed_dir = os.path.join(dst, 'var', 'lib', 'cloud', 'seed')
         cloud_dir = os.path.join(seed_dir, 'nocloud-net')
         os.makedirs(cloud_dir, exist_ok=True)


### PR DESCRIPTION
Trivial branch that ensures that `/etc` files created by `snap prepare-image` also end up in the image.

Sorry for the super short pull-request, the recent feature freeze of snapd made us very busy. The background of this PR is that `snap prepare-image` may now create files in /etc as well. However the current ubuntu-image will not put these files into /etc on the image because it currently only looks for /var. I think ideally ubuntu-image should just include all subdirs (that are not /boot or /home) in the writable partition under the system-data/ dir (just like its doing for /var now). However this was a short term fix.

Note that this fix is important because we change the way that cloud-init is disabled/enabled. Prepare-image now puts a /etc/cloud/cloud-init.disabled file into the image. So without this change images generated by ubuntu-image will start cloud init and casue 5 min boot delays.