### PR TITLE
Add optional --image-size argument.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,8 @@ ubuntu-image (0.8ubuntu1) UNRELEASED; urgency=medium
   * Fix snap creation.  (LP: #1631961)
   * Copy everything under <unpackdir>/image into <rootfs>/system-data
     except boot/.  (LP: #1632134)
+  * Optional --image-size command line option can be used to force the
+    resulting disk image to a larger than calculated size.  (LP: #1632085)
 
  -- Barry Warsaw <barry@ubuntu.com>  Mon, 10 Oct 2016 10:48:49 -0400
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=['ubuntu_image'],
     scripts=['ubuntu-image'],
     entry_points={
-        'flake8.extension': ['B40 = ubuntu_image.testing.flake8:ImportOrder'],
+        'flake8.extension': ['B4 = ubuntu_image.testing.flake8:ImportOrder'],
         },
     license='GPLv3',
     classifiers=(

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -62,7 +62,7 @@ def parseargs(argv=None):
         case, you probably want to specify -w)."""))
     common_group.add_argument(
         '--image-size',
-        default=None, action=SizeAction,
+        default=None, action=SizeAction, metavar='SIZE',
         help=_("""The size of the generated disk image file (see
         -o/--output).  If this size is smaller than the minimum calculated
         size of the image a warning will be issued and --image-size will be

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -9,8 +9,8 @@ import argparse
 from contextlib import suppress
 from pickle import dump, load
 from pkg_resources import resource_string as resource_bytes
-from ubuntu_image.helpers import as_size
 from ubuntu_image.builder import ModelAssertionBuilder
+from ubuntu_image.helpers import as_size
 from ubuntu_image.i18n import _
 
 

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -31,6 +31,8 @@ class SizeAction(argparse.Action):
             raise argparse.ArgumentError(
                 self, 'Invalid size: {}'.format(values))
         setattr(namespace, self.dest, size)
+        # For display purposes.
+        namespace.given_image_size = values
 
 
 def parseargs(argv=None):

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -9,6 +9,7 @@ import argparse
 from contextlib import suppress
 from pickle import dump, load
 from pkg_resources import resource_string as resource_bytes
+from ubuntu_image.helpers import as_size
 from ubuntu_image.builder import ModelAssertionBuilder
 from ubuntu_image.i18n import _
 
@@ -20,6 +21,16 @@ except FileNotFoundError:                           # pragma: nocover
     # Probably, setup.py hasn't been run yet to generate the version.txt.
     __version__ = 'dev'
 PROGRAM = 'ubuntu-image'
+
+
+class SizeAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            size = as_size(values)
+        except (KeyError, ValueError):
+            raise argparse.ArgumentError(
+                self, 'Invalid size: {}'.format(values))
+        setattr(namespace, self.dest, size)
 
 
 def parseargs(argv=None):
@@ -47,6 +58,14 @@ def parseargs(argv=None):
         help=_("""The generated disk image file.  If not given, the image will
         be put in a file called disk.img in the working directory (in which
         case, you probably want to specify -w)."""))
+    common_group.add_argument(
+        '--image-size',
+        default=None, action=SizeAction,
+        help=_("""The size of the generated disk image file (see
+        -o/--output).  If this size is smaller than the minimum calculated
+        size of the image a warning will be issued and --image-size will be
+        ignored.  The value is the size in bytes, with allowable suffixes 'M'
+        for MiB and 'G' for GiB."""))
     # Snap-based image options.
     snap_group = parser.add_argument_group(
         _('Image contents options'),

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -284,8 +284,17 @@ class ModelAssertionBuilder(State):
         #
         # XXX: Hard-codes last 34 512-byte sectors for backup GPT,
         # empirically derived from sgdisk behavior.
-        self.image_size = ceil((self.rootfs_size + next_avail) /
-                               1024 + 17) * 1024
+        calculated = ceil((self.rootfs_size + next_avail) / 1024 + 17) * 1024
+        if self.args.image_size is None:
+            self.image_size = calculated
+        else:
+            if self.args.image_size < calculated:
+                _logger.warning('Ignoring --image-size={} smaller '
+                                'than minimum required size {}'.format(
+                                    self.args.given_image_size, calculated))
+                self.image_size = calculated
+            else:
+                self.image_size = self.args.image_size
         self.root_img = os.path.join(self.images, 'root.img')
         # Create empty file with holes.
         with open(self.root_img,  'w'):

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -110,7 +110,7 @@ def run(command, *, check=True, **args):
         universal_newlines=True,
         **args)
     if check and proc.returncode != 0:
-        sys.__stderr__.write('COMMAND FAILED: {}'.format(command))
+        sys.__stderr__.write('COMMAND FAILED: {}\n'.format(command))
         # Use the real stdout and stderr; the obvious attributes might be
         # mocked out.
         if proc.stdout is not None:

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -93,7 +93,7 @@ class TestHelpers(TestCase):
             run('/bin/false')
         # stdout gets piped to stderr.
         self.assertEqual(stderr.getvalue(),
-                         'COMMAND FAILED: /bin/falsefake stdoutfake stderr')
+                         'COMMAND FAILED: /bin/false\nfake stdoutfake stderr')
 
     def test_run_fails_no_output(self):
         stderr = StringIO()
@@ -105,7 +105,7 @@ class TestHelpers(TestCase):
                       return_value=FakeProcNoOutput()))
             run('/bin/false')
         # stdout gets piped to stderr.
-        self.assertEqual(stderr.getvalue(), 'COMMAND FAILED: /bin/false')
+        self.assertEqual(stderr.getvalue(), 'COMMAND FAILED: /bin/false\n')
 
     def test_as_bool(self):
         for value in {'no', 'False', '0', 'DISABLE', 'DiSaBlEd'}:

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -22,12 +22,15 @@ class TestParseArgs(TestCase):
     def test_image_size_option_bytes(self):
         args = parseargs(['--image-size', '45', 'model.assertion'])
         self.assertEqual(args.image_size, 45)
+        self.assertEqual(args.given_image_size, '45')
 
     def test_image_size_option_suffixes(self):
         args = parseargs(['--image-size', '45G', 'model.assertion'])
         self.assertEqual(args.image_size, GiB(45))
+        self.assertEqual(args.given_image_size, '45G')
         args = parseargs(['--image-size', '45M', 'model.assertion'])
         self.assertEqual(args.image_size, MiB(45))
+        self.assertEqual(args.given_image_size, '45M')
 
     def test_image_size_option_invalid(self):
         # These errors will output to stderr, but that just clouds the test

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -8,13 +8,37 @@ from io import StringIO
 from pickle import load
 from pkg_resources import resource_filename
 from tempfile import TemporaryDirectory
-from ubuntu_image.__main__ import main
+from ubuntu_image.__main__ import main, parseargs
+from ubuntu_image.helpers import GiB, MiB
 from ubuntu_image.testing.helpers import (
     CrashingModelAssertionBuilder, DoNothingBuilder,
     EarlyExitLeaveATraceAssertionBuilder, EarlyExitModelAssertionBuilder,
     XXXModelAssertionBuilder)
 from unittest import TestCase, skipIf
 from unittest.mock import call, patch
+
+
+class TestParseArgs(TestCase):
+    def test_image_size_option_bytes(self):
+        args = parseargs(['--image-size', '45', 'model.assertion'])
+        self.assertEqual(args.image_size, 45)
+
+    def test_image_size_option_suffixes(self):
+        args = parseargs(['--image-size', '45G', 'model.assertion'])
+        self.assertEqual(args.image_size, GiB(45))
+        args = parseargs(['--image-size', '45M', 'model.assertion'])
+        self.assertEqual(args.image_size, MiB(45))
+
+    def test_image_size_option_invalid(self):
+        # These errors will output to stderr, but that just clouds the test
+        # output, so suppress it.
+        with patch('argparse._sys.stderr'):
+            self.assertRaises(SystemExit,
+                              parseargs,
+                              ['--image-size', '45Q', 'model.assertion'])
+            self.assertRaises(SystemExit,
+                              parseargs,
+                              ['--image-size', 'BIG', 'model.assertion'])
 
 
 class TestMain(TestCase):


### PR DESCRIPTION
[LP: #1632085](https://bugs.launchpad.net/ubuntu-image/+bug/1632085)

`--image-size` allows you to specify a larger than calculated size for the resulting disk image.  If the `--image-size` value is less than the calculated size, it is ignored.