### PR TITLE
Round our rootfs partition up to 1MiB for MBR partitions.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,12 @@
-ubuntu-image (0.8+17.04ubuntu1) zesty; urgency=medium
+ubuntu-image (0.9+17.04ubuntu1) zesty; urgency=medium
 
   * Fix snap creation.  (LP: #1631961)
   * Copy everything under <unpackdir>/image into <rootfs>/system-data
     except boot/.  (LP: #1632134)
   * Optional --image-size command line option can be used to force the
     resulting disk image to a larger than calculated size.  (LP: #1632085)
+  * Fix MBR partition size rounding error due to internal bug and implicit
+    sfdisk(8) behavior.  Give by Steve Langasek.  (LP: #1634557)
 
  -- Barry Warsaw <barry@ubuntu.com>  Mon, 10 Oct 2016 10:48:49 -0400
 

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -403,7 +403,7 @@ class ModelAssertionBuilder(State):
         # Create main snappy writable partition as the last partition.
         image.partition(
             part_id,
-            new='{}M:+{}K'.format(next_offset, self.rootfs_size // 1024),
+            new='{}M:+{}K'.format(next_offset, ceil(self.rootfs_size / 1024)),
             typecode=('83', '0FC63DAF-8483-4772-8E79-3D69D8477DE4'))
         if volume.schema is VolumeSchema.gpt:
             image.partition(part_id, change_name='writable')

--- a/ubuntu_image/image.py
+++ b/ubuntu_image/image.py
@@ -174,7 +174,7 @@ class MBRImage(Image):
                 # it down to where it was supposed to be in the first place.
                 if size.endswith('K'):
                     size = int(size.rstrip('K').lstrip('+'))
-                    size = '+{}M'.format(ceil(size/1024))
+                    size = '+{}M'.format(ceil(size / 1024))
                 command_input.extend([
                     'start={}'.format(offset),
                     'size={}'.format(size),

--- a/ubuntu_image/image.py
+++ b/ubuntu_image/image.py
@@ -3,6 +3,7 @@
 import os
 
 from enum import Enum
+from math import ceil
 from struct import pack
 from ubuntu_image.helpers import run
 
@@ -167,6 +168,13 @@ class MBRImage(Image):
         for key, value in sfdisk_args.items():
             if key == 'new':
                 offset, size = value.split(':')
+                # XXX: special behavior from sfdisk: it rounds our partition
+                # size down to the nearest MiB without asking.  So round up,
+                # and if it extends past the end of the disk sfdisk will round
+                # it down to where it was supposed to be in the first place.
+                if size.endswith('K'):
+                    size = int(size.rstrip('K').lstrip('+'))
+                    size = '+{}M'.format(ceil(size/1024))
                 command_input.extend([
                     'start={}'.format(offset),
                     'size={}'.format(size),


### PR DESCRIPTION
In e660cb5, we relaxed the alignment requirements for the root partition.
However, in addition to an implementation bug that incorrectly caused us to
round down to the nearest 1KiB (instead of up), it appears that sfdisk
forces a 1MiB alignment on partitions and it *also* rounds down.

We ultimately want to fix this to support < 1MiB alignment for partitions,
but in the near term since the underlying tooling is requiring it, fix how
we invoke the partition tools to avoid declaring partitions that are
undersized for our filesystem.

LP: #1634557