### PR TITLE
100% test coverage for Xenial. (LP:1637181)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+ubuntu-image (0.10+16.04ubuntu2) xenial; urgency=medium
+
+  * 100% test coverage for Xenial. (LP:1637181)
+  * SRU tracking bug LP: #1636560
+
+ -- Barry Warsaw <barry@ubuntu.com>  Thu, 27 Oct 2016 18:59:21 -0400
+
 ubuntu-image (0.10+16.04ubuntu1) xenial; urgency=medium
 
-  * SRU tracking bug LP: #1636560
   * Only write out nocloud-net metadata file (thus indicating a local seed
     and preventing a search elsewhere for user data) when the --cloud-init
     parameter is given.  (LP:1633232)

--- a/debian/tests/control.autodep8
+++ b/debian/tests/control.autodep8
@@ -9,12 +9,15 @@ Depends: @, man-db
 
 Test-Command: tox -e py35
 Depends: @builddeps@, git
+Restrictions: needs-root
 
 Test-Command: tox -e qa
 Depends: @builddeps@, git
+Restrictions: needs-root
 
 Test-Command: tox -e coverage
 Depends: @builddeps@, git
+Restrictions: needs-root
 
 Tests: mount
 Restrictions: needs-root, allow-stderr

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -168,7 +168,7 @@ def mkfs_ext4(img_file, contents_dir, label='writable'):
     proc = run(cmd, check=False)
     if proc.returncode == 0:
         # We have a new enough e2fsprogs, so we're done.
-        return
+        return                                      # pragma: nocover
     run('mkfs.ext4 -L {} -T default -O uninit_bg {}'.format(label, img_file))
     # Only do this if the directory is non-empty.
     if not os.listdir(contents_dir):


### PR DESCRIPTION
Two things that are only needed on Xenial:

* Add a `pragma: nocover` for a code path that will never be taken on Xenial
* Run the tox-based autopkgtests with `Restriction: needs-root` since sudo is required.

This seems like the least offensive way to handle [LP: #1637181](https://bugs.launchpad.net/ubuntu-image/+bug/1637181) and is **not** necessary for Yakkety and newer.