### PR TITLE
Sort structures by offset

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+ubuntu-image (0.11+17.04ubuntu1) UNRELEASED; urgency=medium
+
+  * Sort the structures in a volume by their offset, even if the offset is
+    defined implicitly (i.e. not present in the gadget.yaml).  Also, check
+    for any structure conflicts and raise a ValueError in that case.
+    (LP: #1631423)
+
+ -- Barry Warsaw <barry@ubuntu.com>  Tue, 01 Nov 2016 16:52:54 -0400
+
 ubuntu-image (0.10+17.04ubuntu1) zesty; urgency=medium
 
   * Only write out nocloud-net metadata file (thus indicating a local seed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: ubuntu-image
 summary: Create Ubuntu images
 description: |
   Use this tool to create Ubuntu images.
-version: 0.10+real1
+version: 0.11+real1
 confinement: devmode
 
 apps:

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -6,7 +6,6 @@ import shutil
 import logging
 
 from math import ceil
-from operator import attrgetter
 from tempfile import TemporaryDirectory
 from ubuntu_image.helpers import MiB, mkfs_ext4, run, snap, sparse_copy
 from ubuntu_image.image import Image, MBRImage

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -370,12 +370,10 @@ class ModelAssertionBuilder(State):
             image = MBRImage(self.disk_img, self.image_size)
         else:
             image = Image(self.disk_img, self.image_size)
-        # XXX LP: #1630627
-        structures = sorted(volume.structures, key=attrgetter('offset'))
         offset_writes = []
         part_offsets = {}
         next_offset = 1
-        for i, part in enumerate(structures):
+        for i, part in enumerate(volume.structures):
             if part.name is not None:
                 part_offsets[part.name] = part.offset
             if part.offset_write is not None:

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -748,7 +748,8 @@ class TestModelAssertionBuilder(TestCase):
                 offset_write=None,
                 )
             volume = SimpleNamespace(
-                structures=[part0, part1, part2],
+                # Ordered by offset, as would happen by the parser.
+                structures=[part2, part0, part1],
                 schema=VolumeSchema.gpt,
                 )
             state.gadget = SimpleNamespace(


### PR DESCRIPTION
[LP: #1631423](https://bugs.launchpad.net/ubuntu-image/+bug/1631423)

Calculate partition offsets if missing from the gadget.yaml.  Check for conflicts in partition layout and raise a `ValueError` in that case.