### PR TITLE
At parse time, make sure that offset-write values can fit into 32-bit integers

### DIFF
--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -58,21 +58,26 @@ def straight_up_bytes(count):
     return count
 
 
-def as_size(size):
+def as_size(size, min=0, max=None):
     # Check for int-ness and just return what you get if so.  YAML parsers
     # will turn values like '108' into ints automatically, but voluptuous will
     # always try to coerce the value to an as_size.
     if isinstance(size, int):
-        return size
-    mo = re.match('(\d+)([a-zA-Z]*)', size)
-    if mo is None:
-        raise ValueError(size)
-    size_in_bytes = mo.group(1)
-    return {
-        '': straight_up_bytes,
-        'G': GiB,
-        'M': MiB,
-        }[mo.group(2)](int(size_in_bytes))
+        value = size
+    else:
+        mo = re.match('(\d+)([a-zA-Z]*)', size)
+        if mo is None:
+            raise ValueError(size)
+        size_in_bytes = mo.group(1)
+        value = {
+            '': straight_up_bytes,
+            'G': GiB,
+            'M': MiB,
+            }[mo.group(2)](int(size_in_bytes))
+    if ((isinstance(min, int) and not value >= min) or
+            (isinstance(max, int) and not value < max)):
+        raise ValueError
+    return value
 
 
 def transform(caught_excs, new_exc):

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -6,8 +6,7 @@ import attr
 from enum import Enum
 from io import StringIO
 from operator import methodcaller
-from struct import error, pack
-from ubuntu_image.helpers import MiB, as_size, transform
+from ubuntu_image.helpers import GiB, MiB, as_size, transform
 from uuid import UUID
 from voluptuous import Any, Coerce, Invalid, Match, Optional, Required, Schema
 from yaml import load
@@ -67,12 +66,7 @@ class Enumify:
 
 def Size32bit(v):
     """Coerce size to being a 32 bit integer."""
-    b = as_size(v)
-    try:
-        pack('I', b)
-    except error:
-        raise ValueError(v)
-    return b
+    return as_size(v, max=GiB(4))
 
 
 def Id(v):

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -6,6 +6,7 @@ import attr
 from enum import Enum
 from io import StringIO
 from operator import methodcaller
+from struct import error, pack
 from ubuntu_image.helpers import MiB, as_size, transform
 from uuid import UUID
 from voluptuous import Any, Coerce, Invalid, Match, Optional, Required, Schema
@@ -64,6 +65,16 @@ class Enumify:
             ]
 
 
+def Size32bit(v):
+    """Coerce size to being a 32 bit integer."""
+    b = as_size(v)
+    try:
+        pack('I', b)
+    except error:
+        raise ValueError(v)
+    return b
+
+
 def Id(v):
     """Coerce to either a hex UUID, a 2-digit hex value."""
     if isinstance(v, int):
@@ -108,7 +119,7 @@ def RelativeOffset(v):
     label, plus, offset = v.partition('+')
     if len(label) == 0 or plus != '+' or len(offset) == 0:
         raise ValueError(v)
-    return label, as_size(offset)
+    return label, Size32bit(offset)
 
 
 GadgetYAML = Schema({
@@ -124,7 +135,8 @@ GadgetYAML = Schema({
             Required('structure'): [Schema({
                 Optional('name'): str,
                 Optional('offset'): Coerce(as_size),
-                Optional('offset-write'): Any(Coerce(as_size), RelativeOffset),
+                Optional('offset-write'): Any(
+                    Coerce(Size32bit), RelativeOffset),
                 Required('size'): Coerce(as_size),
                 Required('type'): Any('mbr', Coerce(HybridId)),
                 Optional('id'): Coerce(UUID),
@@ -141,7 +153,7 @@ GadgetYAML = Schema({
                         Required('image'): str,
                         Optional('offset'): Coerce(as_size),
                         Optional('offset-write'): Any(
-                            Coerce(as_size), RelativeOffset),
+                            Coerce(Size32bit), RelativeOffset),
                         Optional('size'): Coerce(as_size),
                         })
                     ],

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -76,6 +76,19 @@ class TestHelpers(TestCase):
     def test_bytes(self):
         self.assertEqual(as_size('801'), 801)
 
+    def test_size_min(self):
+        self.assertEqual(as_size(5, min=4), 5)
+        self.assertRaises(ValueError, as_size, 3, min=4)
+
+    def test_size_max(self):
+        self.assertEqual(as_size(5, max=8), 5)
+        self.assertRaises(ValueError, as_size, 10, max=8)
+
+    def test_size_min_max(self):
+        self.assertEqual(as_size(5, min=4, max=8), 5)
+        self.assertRaises(ValueError, as_size, 3, min=4, max=8)
+        self.assertRaises(ValueError, as_size, 10, min=4, max=8)
+
     def test_transform(self):
         @transform(ZeroDivisionError, RuntimeError)
         def oops():

--- a/ubuntu_image/tests/test_parser.py
+++ b/ubuntu_image/tests/test_parser.py
@@ -387,6 +387,18 @@ volumes:
           offset-write: some_label%2112
 """)
 
+    def test_volume_offset_write_larger_than_32bit(self):
+        self.assertRaises(ValueError, parse, """\
+volumes:
+  first-image:
+    schema: gpt
+    bootloader: u-boot
+    structure:
+        - type: 00000000-0000-0000-0000-0000deadbeef
+          size: 400M
+          offset-write: 8G
+""")
+
     def test_volume_size(self):
         gadget_spec = parse("""\
 volumes:
@@ -778,6 +790,20 @@ volumes:
         self.assertIsNone(content0.offset)
         self.assertEqual(content0.offset_write, ('label', 2112))
         self.assertIsNone(content0.size)
+
+    def test_content_spec_b_offset_write_larger_than_32bit(self):
+        self.assertRaises(ValueError, parse, """\
+volumes:
+  first-image:
+    schema: gpt
+    bootloader: u-boot
+    structure:
+        - type: 00000000-0000-0000-0000-0000deadbeef
+          size: 400M
+          content:
+          - image: foo.img
+            offset-write: 8G
+""")
 
     def test_content_spec_b_size(self):
         gadget_spec = parse("""\


### PR DESCRIPTION
(LP: #1617443).