### PR TITLE
LP: #1640523

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -20,6 +20,8 @@ ubuntu-image (0.12+17.04ubuntu1) UNRELEASED; urgency=medium
   * Skip some tests which touch the actual store when running without
     network access (e.g. during package build time).
   * Move the __version__ calculation to the package's __init__.py
+  * Parse all YAML integer-like values as strings, and then turn them into
+    integers if necessary during post-processing.  (LP: #1640523)
 
  -- Barry Warsaw <barry@ubuntu.com>  Tue, 08 Nov 2016 17:31:21 -0500
 

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -59,21 +59,15 @@ def straight_up_bytes(count):
 
 
 def as_size(size, min=0, max=None):
-    # Check for int-ness and just return what you get if so.  YAML parsers
-    # will turn values like '108' into ints automatically, but voluptuous will
-    # always try to coerce the value to an as_size.
-    if isinstance(size, int):
-        value = size
-    else:
-        mo = re.match('(\d+)([a-zA-Z]*)', size)
-        if mo is None:
-            raise ValueError(size)
-        size_in_bytes = mo.group(1)
-        value = {
-            '': straight_up_bytes,
-            'G': GiB,
-            'M': MiB,
-            }[mo.group(2)](int(size_in_bytes))
+    mo = re.match('(\d+)([a-zA-Z]*)', size)
+    if mo is None:
+        raise ValueError(size)
+    size_in_bytes = mo.group(1)
+    value = {
+        '': straight_up_bytes,
+        'G': GiB,
+        'M': MiB,
+        }[mo.group(2)](int(size_in_bytes))
     if max is None:
         if value < min:
             raise ValueError('Value outside range: {} < {}'.format(value, min))

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -78,29 +78,29 @@ class TestHelpers(TestCase):
         self.assertEqual(as_size('801'), 801)
 
     def test_size_min_okay(self):
-        self.assertEqual(as_size(5, min=4), 5)
+        self.assertEqual(as_size('5', min=4), 5)
 
     def test_size_value_less_than_min(self):
-        self.assertRaises(ValueError, as_size, 3, min=4)
+        self.assertRaises(ValueError, as_size, '3', min=4)
 
     def test_size_min_inclusive_okay(self):
-        self.assertEqual(as_size(3, min=3), 3)
+        self.assertEqual(as_size('3', min=3), 3)
 
     def test_size_max_okay(self):
-        self.assertEqual(as_size(5, max=8), 5)
+        self.assertEqual(as_size('5', max=8), 5)
 
     def test_size_value_greater_than_max(self):
-        self.assertRaises(ValueError, as_size, 10, max=8)
+        self.assertRaises(ValueError, as_size, '10', max=8)
 
     def test_size_max_exclusive(self):
-        self.assertRaises(ValueError, as_size, 10, max=10)
+        self.assertRaises(ValueError, as_size, '10', max=10)
 
     def test_size_min_max(self):
-        self.assertEqual(as_size(5, min=4, max=8), 5)
+        self.assertEqual(as_size('5', min=4, max=8), 5)
 
     def test_size_min_max_outside_range(self):
-        self.assertRaises(ValueError, as_size, 3, min=4, max=8)
-        self.assertRaises(ValueError, as_size, 10, min=4, max=8)
+        self.assertRaises(ValueError, as_size, '3', min=4, max=8)
+        self.assertRaises(ValueError, as_size, '10', min=4, max=8)
 
     def test_run(self):
         with ExitStack() as resources:

--- a/ubuntu_image/tests/test_parser.py
+++ b/ubuntu_image/tests/test_parser.py
@@ -856,7 +856,7 @@ volumes:
             'some-value')
         self.assertEqual(
             gadget_spec.defaults['mfq0tsAY']['other-key'],
-            42)
+            '42')
 
 
 class TestParserErrors(TestCase):


### PR DESCRIPTION
Parse all YAML integer-like values as strings, and then turn them into
integers if necessary during post-processing.