### PR TITLE
LP: #1642427

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -26,6 +26,8 @@ ubuntu-image (0.12+17.04ubuntu1) UNRELEASED; urgency=medium
     version number supported by the gadget.yaml.  Currently only format 0
     is supported, which is a legacy version (omitting the format is
     equivalent).  (LP: #1638926)
+  * d/control: Add run-time dependencies which are missing from snapd but
+    are required for `snap prepare-image`.  (LP: #1642427)
 
  -- Barry Warsaw <barry@ubuntu.com>  Tue, 08 Nov 2016 17:31:21 -0500
 

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Build-Depends: debhelper (>= 9),
                python3-voluptuous,
                python3-yaml,
                snapd (>= 2.0.11~ppa0),
-               tox
+               tox,
 Standards-Version: 3.9.8
 Homepage: http://launchpad.net/ubuntu-image
 
@@ -28,7 +28,7 @@ Package: ubuntu-image
 Architecture: all
 Depends: python3-ubuntu-image (= ${binary:Version}),
          ${misc:Depends},
-         ${python3:Depends}
+         ${python3:Depends},
 Description: toolkit for building Ubuntu images.
  .
  This package contains the ubuntu-image program.
@@ -48,7 +48,7 @@ Depends: ca-certificates,
          python3-yaml,
          snapd,
          ${misc:Depends},
-         ${python3:Depends}
+         ${python3:Depends},
 Description: toolkit for building Ubuntu images
  .
  This package contains the ubuntu-image library for Python 3.

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends: debhelper (>= 9),
                dh-python,
                dosfstools,
                gdisk,
+               grub-common,
                mtools,
                python3-all,
                python3-attr,
@@ -19,8 +20,7 @@ Build-Depends: debhelper (>= 9),
                python3-voluptuous,
                python3-yaml,
                snapd (>= 2.0.11~ppa0),
-               grub-common,
-               tox,
+               tox
 Standards-Version: 3.9.8
 Homepage: http://launchpad.net/ubuntu-image
 
@@ -28,7 +28,7 @@ Package: ubuntu-image
 Architecture: all
 Depends: python3-ubuntu-image (= ${binary:Version}),
          ${misc:Depends},
-         ${python3:Depends},
+         ${python3:Depends}
 Description: toolkit for building Ubuntu images.
  .
  This package contains the ubuntu-image program.
@@ -36,8 +36,10 @@ Description: toolkit for building Ubuntu images.
 Package: python3-ubuntu-image
 Architecture: all
 Section: python
-Depends: dosfstools,
+Depends: ca-certificates,
+         dosfstools,
          gdisk,
+         grub-common,
          mtools (>= 4.0.18-2ubuntu0),
          python3-attr,
          python3-pkg-resources,
@@ -46,7 +48,7 @@ Depends: dosfstools,
          python3-yaml,
          snapd,
          ${misc:Depends},
-         ${python3:Depends},
+         ${python3:Depends}
 Description: toolkit for building Ubuntu images
  .
  This package contains the ubuntu-image library for Python 3.

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -23,4 +23,4 @@ Depends: @builddeps@, git, lsb-release
 
 Tests: mount
 Restrictions: needs-root, allow-stderr
-Depends: @, kpartx, ca-certificates, grub-common
+Depends: @, kpartx


### PR DESCRIPTION
d/control: Add run-time dependencies which are missing from snapd but are required for `snap prepare-image`.  (LP: #1642427)
