### PR TITLE
Don't write images to /tmp when running ubuntu-image as a snap

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 ubuntu-image (0.13+17.04ubuntu1) UNRELEASED; urgency=medium
 
-  *
+  * Refuse to write images to /tmp when running ubuntu-image as a snap,
+    since the snap's /tmp is not accessible to the user.  (LP: #1646968)
 
  -- Barry Warsaw <barry@ubuntu.com>  Thu, 01 Dec 2016 17:33:19 -0500
 

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -3,20 +3,25 @@ Depends: python3-ubuntu-image
 
 Test-Command: ubuntu-image --help
 Depends: ubuntu-image
+Features: test-name=help
 
 Test-Command: ubuntu-image --version
 Depends: ubuntu-image
+Features: test-name=version
 
 Test-Command: man ubuntu-image
 Depends: ubuntu-image, man-db
+Features: test-name=manpage
 
 # Something in the tox/pip/setuptools stack requires git.
 
 Test-Command: tox -e py35
 Depends: @builddeps@, git
+Features: test-name=unittests
 
 Test-Command: tox -e qa
 Depends: @builddeps@, git
+Features: test-name=qa
 
 Tests: coverage.sh
 Depends: @builddeps@, git, lsb-release

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -8,7 +8,8 @@ import argparse
 from contextlib import suppress
 from pickle import dump, load
 from ubuntu_image import __version__
-from ubuntu_image.builder import ModelAssertionBuilder
+from ubuntu_image.builder import (
+    ModelAssertionBuilder, TMPNotReadableFromOutsideSnap)
 from ubuntu_image.helpers import as_size
 from ubuntu_image.i18n import _
 from ubuntu_image.parser import GadgetSpecificationError
@@ -147,7 +148,11 @@ def main(argv=None):
             state_machine = load(fp)
         state_machine.workdir = args.workdir
     else:
-        state_machine = ModelAssertionBuilder(args)
+        try:
+            state_machine = ModelAssertionBuilder(args)
+        except TMPNotReadableFromOutsideSnap as error:
+            print(error.__doc__, file=sys.stderr)
+            return 1
     # Run the state machine, either to the end or thru/until the named state.
     try:
         if args.thru:

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -61,7 +61,7 @@ class TestModelAssertionBuilder(TestCase):
             debug=False,
             extra_snaps=None,
             model_assertion=self.model_assertion,
-            output=output,
+            output=output.name,
             workdir=None,
             )
         state = self._resources.enter_context(XXXModelAssertionBuilder(args))


### PR DESCRIPTION
[LP: #1646968](https://bugs.launchpad.net/ubuntu-image/+bug/1646968)

`/tmp` to the snap is not `/tmp` to the user.  The former is not accessible to the user so u-i should refuse to write images to that location in that case.