### PR TITLE
Sparse copy without preserving timestamps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ ubuntu-image (0.13+17.04ubuntu1) UNRELEASED; urgency=medium
     mode,ownership,timestamps.  Over remote file systems (e.g. afp, hgfs)
     this can fail.  Over local file systems, they'll be preserved anyway.
     (LP: #1637554)
+  * d/tests/mount: Switch to the stable channel for snaps.
 
  -- Barry Warsaw <barry@ubuntu.com>  Thu, 01 Dec 2016 17:33:19 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,8 @@ ubuntu-image (0.13+17.04ubuntu1) UNRELEASED; urgency=medium
   * Refuse to write images to /tmp when running ubuntu-image as a snap,
     since the snap's /tmp is not accessible to the user.  (LP: #1646968)
   * When sparse copying the resulting disk image, don't try to preserve
-    timestamps.  It isn't that important and it fails when copying the
-    file to certain destinations (e.g. afp mounted directories).
+    mode,ownership,timestamps.  Over remote file systems (e.g. afp, hgfs)
+    this can fail.  Over local file systems, they'll be preserved anyway.
     (LP: #1637554)
 
  -- Barry Warsaw <barry@ubuntu.com>  Thu, 01 Dec 2016 17:33:19 -0500

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,10 @@ ubuntu-image (0.13+17.04ubuntu1) UNRELEASED; urgency=medium
 
   * Refuse to write images to /tmp when running ubuntu-image as a snap,
     since the snap's /tmp is not accessible to the user.  (LP: #1646968)
+  * When sparse copying the resulting disk image, don't try to preserve
+    timestamps.  It isn't that important and it fails when copying the
+    file to certain destinations (e.g. afp mounted directories).
+    (LP: #1637554)
 
  -- Barry Warsaw <barry@ubuntu.com>  Thu, 01 Dec 2016 17:33:19 -0500
 

--- a/debian/tests/mount
+++ b/debian/tests/mount
@@ -23,7 +23,7 @@ from ubuntu_image.parser import FileSystemType, parse
 TMP = os.environ['AUTOPKGTEST_TMP']
 DIR = os.path.abspath(os.path.join('debian', 'tests', 'models'))
 STATUS = {}
-CHANNEL = 'beta'
+CHANNEL = 'stable'
 
 
 for model_file in os.listdir(DIR):

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -117,7 +117,7 @@ def snap(model_assertion, root_dir, channel=None, extra_snaps=None):
 
 
 def sparse_copy(src, dst, *, follow_symlinks=True):
-    args = ['cp', '--preserve=mode,ownership', '--sparse=always', src, dst]
+    args = ['cp', '--sparse=always', src, dst]
     if not follow_symlinks:
         args.append('-P')
     run(args)

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -117,7 +117,7 @@ def snap(model_assertion, root_dir, channel=None, extra_snaps=None):
 
 
 def sparse_copy(src, dst, *, follow_symlinks=True):
-    args = ['cp', '-p', '--sparse=always', src, dst]
+    args = ['cp', '--preserve=mode,ownership', '--sparse=always', src, dst]
     if not follow_symlinks:
         args.append('-P')
     run(args)


### PR DESCRIPTION
When sparse copying the resulting disk image, don't try to preserve timestamps.  It isn't that important and it fails when copying the file to certain destinations (e.g. afp mounted directories).

[LP: #1637554](https://bugs.launchpad.net/ubuntu-image/+bug/1637554)