### PR TITLE
Add -O/--output-dir command line options.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-image (0.15+17.04ubuntu1) UNRELEASED; urgency=medium
+
+  * Add -O/--output-dir command line options.  Disk image files are
+    written here using the volume name and a .img suffix.
+
+ -- Barry Warsaw <barry@ubuntu.com>  Tue, 24 Jan 2017 18:01:23 -0500
+
 ubuntu-image (0.14+17.04ubuntu1) zesty; urgency=medium
 
   * Add CI for Python 3.6.  (LP: #1650402)

--- a/ubuntu-image.rst
+++ b/ubuntu-image.rst
@@ -7,9 +7,9 @@ Generate a bootable disk image
 ------------------------------
 
 :Author: Barry Warsaw <barry@ubuntu.com>
-:Date: 2016-11-01
-:Copyright: 2016 Canonical Ltd.
-:Version: 0.11
+:Date: 2017-01-24
+:Copyright: 2016-2017 Canonical Ltd.
+:Version: 0.15
 :Manual section: 1
 
 
@@ -67,8 +67,16 @@ model_assertion
 
 -o FILENAME, --output FILENAME
     The generated disk image file.  If not given, the image will be put in a
-    file called ``disk.img`` in the working directory (in which case, you
-    probably want to specify ``--workdir``).
+    file called ``disk.img`` in the working directory, in which case, you
+    probably want to specify ``--workdir``.  If ``--workdir`` is not given,
+    the image will be written to the current working directory.  **NOTE** when
+    run as a snap, ``ubuntu-image`` refuses to write to ``/tmp`` since this
+    directory is not accessible outside of the snap environment.
+
+-O DIRECTORY, --output-dir DIRECTORY
+    Write generated disk image files to this directory.  The files will be
+    named after the ``gadget.yaml`` volume name, with ``.img`` suffix
+    appended.  **NOTE** when run as a snap, this directory cannot be ``/tmp``.
 
 --image-size SIZE
     The size of the generated disk image file (see ``--output``).  If this

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -59,6 +59,14 @@ def parseargs(argv=None):
         be put in a file called disk.img in the working directory (in which
         case, you probably want to specify -w)."""))
     common_group.add_argument(
+        '-O', '--output-dir',
+        default=None, metavar='DIRECTORY',
+        help=_("""The directory in which to put generated disk image files.
+        The disk image files themselves will be named <volume>.img inside this
+        directory, where <volume> is the volume name taken from the
+        gadget.yaml file.  This can be overridden on an individual volume
+        basis by using the extended -o/--output syntax."""))
+    common_group.add_argument(
         '--image-size',
         default=None, action=SizeAction, metavar='SIZE',
         help=_("""The size of the generated disk image file (see

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -8,7 +8,7 @@ from math import ceil
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
-from ubuntu_image.helpers import MiB, mkfs_ext4, run, snap, sparse_copy
+from ubuntu_image.helpers import MiB, mkfs_ext4, run, snap
 from ubuntu_image.image import Image, MBRImage
 from ubuntu_image.parser import (
     BootLoader, FileSystemType, StructureRole, VolumeSchema,
@@ -43,14 +43,21 @@ class ModelAssertionBuilder(State):
         # Where the disk.img file ends up.  /tmp to a snap is not the same
         # /tmp outside of the snap.  When running as a snap, don't allow the
         # user to output a disk image to a location that won't exist for them.
-        self.output = (
-            os.path.join(self.workdir, 'disk.img')
-            if args.output is None
-            else args.output)
-        in_snap = any(key.startswith('SNAP') for key in os.environ)
-        path = os.sep.join(self.output.split(os.sep)[:2])
-        if in_snap and path == '/tmp':
-            raise TMPNotReadableFromOutsideSnap
+        # When run as a snap, /tmp is not writable.
+        if any(key.startswith('SNAP') for key in os.environ):
+            # The output directories, in order of precedence.
+            for path in (args.output, args.output_dir, os.getcwd()):
+                if path is None:
+                    continue
+                path = os.sep.join(path.split(os.sep)[:2])
+                if path == '/tmp':
+                    raise TMPNotReadableFromOutsideSnap
+                else:
+                    # This path is okay and since it'll take precedence, we're
+                    # done checking.
+                    break
+        self.output_dir = args.output_dir
+        self.output = args.output
         # Information passed between states.
         self.rootfs = None
         self.rootfs_size = 0
@@ -81,6 +88,7 @@ class ModelAssertionBuilder(State):
             image_size=self.image_size,
             images=self.images,
             output=self.output,
+            output_dir=self.output_dir,
             part_images=self.part_images,
             rootfs=self.rootfs,
             rootfs_size=self.rootfs_size,
@@ -100,6 +108,7 @@ class ModelAssertionBuilder(State):
         self.image_size = state['image_size']
         self.images = state['images']
         self.output = state['output']
+        self.output_dir = state['output_dir']
         self.part_images = state['part_images']
         self.rootfs = state['rootfs']
         self.rootfs_size = state['rootfs_size']
@@ -138,6 +147,26 @@ class ModelAssertionBuilder(State):
         shutil.copy(yaml_file, self.workdir)
         with open(yaml_file, 'r', encoding='utf-8') as fp:
             self.gadget = parse_yaml(fp)
+        # Based on the -o/--output and -O/--output-dir options, and the volumes
+        # in the gadget.yaml file, we can now calculate where the generated
+        # disk images should go.  We'll write them directly to the final
+        # destination so they don't have to be moved later.  Here is the
+        # option precedence:
+        #
+        # * The location specified by -o/--output;
+        # * <output_dir>/<volume_name>.img
+        # * <work_dir>/disk.img
+        if self.output is not None:
+            self.disk_img = self.output
+        elif self.output_dir is not None:
+            os.makedirs(self.output_dir, exist_ok=True)
+            volumes = self.gadget.volumes.keys()
+            assert len(volumes) == 1, 'For now, only one volume is allowed'
+            volume = list(volumes)[0]
+            self.disk_img = os.path.join(
+                self.output_dir, '{}.img'.format(volume))
+        else:
+            self.disk_img = os.path.join(self.workdir, 'disk.img')
         self._next.append(self.populate_rootfs_contents)
 
     def populate_rootfs_contents(self):
@@ -383,7 +412,6 @@ class ModelAssertionBuilder(State):
         self._next.append(self.make_disk)
 
     def make_disk(self):
-        self.disk_img = os.path.join(self.images, 'disk.img')
         part_id = 1
         # Walk through all partitions and write them to the disk image at the
         # lowest permissible offset.  We should not have any overlapping
@@ -443,7 +471,4 @@ class ModelAssertionBuilder(State):
         self._next.append(self.finish)
 
     def finish(self):
-        # Move the completed disk image to destination location, since the
-        # temporary scratch directory is about to get removed.
-        shutil.move(self.disk_img, self.output, copy_function=sparse_copy)
         self._next.append(self.close)

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -46,16 +46,21 @@ class ModelAssertionBuilder(State):
         # When run as a snap, /tmp is not writable.
         if any(key.startswith('SNAP') for key in os.environ):
             # The output directories, in order of precedence.
-            for path in (args.output, args.output_dir, os.getcwd()):
+            check_paths = (args.output, args.output_dir, os.getcwd())
+            # This loop will never exit normally because either we'll hit a
+            # /tmp directory, or we won't.  In the former case we'll always
+            # exit by raising the exception, and in the latter case, we'll hit
+            # the break.  Therefore, tell coverage not to check partial
+            # branches for this loop.
+            for path in check_paths:                # pragma: no branch
                 if path is None:
                     continue
                 path = os.sep.join(path.split(os.sep)[:2])
                 if path == '/tmp':
                     raise TMPNotReadableFromOutsideSnap
-                else:
-                    # This path is okay and since it'll take precedence, we're
-                    # done checking.
-                    break
+                # This path is okay and since it'll take precedence, we're
+                # done checking.
+                break
         self.output_dir = args.output_dir
         self.output = args.output
         # Information passed between states.

--- a/ubuntu_image/tests/data/gadget-multi.yaml
+++ b/ubuntu_image/tests/data/gadget-multi.yaml
@@ -1,0 +1,30 @@
+volumes:
+  first:
+    bootloader: grub
+    structure:
+      - name: EFI System
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        filesystem-label: system-boot
+        size: 50M
+        content:
+          - source: grubx64.efi
+            target: EFI/boot/grubx64.efi
+          - source: shim.efi.signed
+            target: EFI/boot/bootx64.efi
+          - source: grub.cfg
+            target: EFI/boot/grub.cfg
+  second:
+    structure:
+        - type: 00000000-0000-0000-0000-0000feedface
+          size: 200
+          role: system-boot
+  third:
+    structure:
+        - type: 00000000-0000-0000-0000-0000deafbead
+          size: 300
+          role: system-data
+  fourth:
+    structure:
+        - type: 00000000-0000-0000-0000-0000deafbead
+          size: 400

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -63,6 +63,7 @@ class TestModelAssertionBuilder(TestCase):
             extra_snaps=None,
             model_assertion=self.model_assertion,
             output=output.name,
+            output_dir=None,
             workdir=None,
             )
         state = self._resources.enter_context(XXXModelAssertionBuilder(args))
@@ -126,6 +127,7 @@ class TestModelAssertionBuilder(TestCase):
                 extra_snaps=None,
                 model_assertion=self.model_assertion,
                 output=None,
+                output_dir=None,
                 workdir=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -162,6 +164,7 @@ class TestModelAssertionBuilder(TestCase):
                 extra_snaps=None,
                 model_assertion=self.model_assertion,
                 output=None,
+                output_dir=None,
                 workdir=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -197,6 +200,7 @@ class TestModelAssertionBuilder(TestCase):
                 extra_snaps=None,
                 model_assertion=self.model_assertion,
                 output=None,
+                output_dir=None,
                 workdir=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -241,6 +245,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -296,6 +301,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 debug=False,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -338,6 +344,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -411,6 +418,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 debug=False,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -457,6 +465,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -487,6 +496,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -573,6 +583,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -636,6 +647,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 debug=False,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -691,6 +703,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 debug=False,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -734,6 +747,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -856,6 +870,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -938,6 +953,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -1063,6 +1079,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -1129,6 +1146,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -1205,6 +1223,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 image_size=None,
                 output=None,
+                output_dir=None,
                 unpackdir=None,
                 workdir=workdir,
                 )
@@ -1258,6 +1277,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 image_size=None,
                 output=None,
+                output_dir=None,
                 unpackdir=None,
                 workdir=workdir,
                 )
@@ -1304,6 +1324,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 image_size=MiB(5),
                 output=None,
+                output_dir=None,
                 unpackdir=None,
                 workdir=workdir,
                 )
@@ -1352,6 +1373,7 @@ class TestModelAssertionBuilder(TestCase):
                 given_image_size='1M',
                 image_size=MiB(1),
                 output=None,
+                output_dir=None,
                 unpackdir=None,
                 workdir=workdir,
                 )
@@ -1413,6 +1435,7 @@ class TestModelAssertionBuilder(TestCase):
                 given_image_size='3M',
                 image_size=MiB(3),
                 output=None,
+                output_dir=None,
                 unpackdir=None,
                 workdir=workdir,
                 )
@@ -1499,6 +1522,7 @@ class TestModelAssertionBuilder(TestCase):
             args = SimpleNamespace(
                 cloud_init=None,
                 output=None,
+                output_dir=None,
                 unpackdir=unpackdir,
                 workdir=workdir,
                 )
@@ -1576,6 +1600,7 @@ class TestModelAssertionBuilder(TestCase):
                 given_image_size='1M',
                 image_size=MiB(1),
                 output=None,
+                output_dir=None,
                 unpackdir=None,
                 workdir=workdir,
                 )
@@ -1639,6 +1664,7 @@ class TestModelAssertionBuilder(TestCase):
                 extra_snaps=[],
                 model_assertion=self.model_assertion,
                 output=None,
+                output_dir=None,
                 workdir=workdir,
                 )
             # Jump right to the method under test.
@@ -1686,6 +1712,7 @@ class TestModelAssertionBuilder(TestCase):
                 extra_snaps=[],
                 model_assertion=self.model_assertion,
                 output=None,
+                output_dir=None,
                 workdir=workdir,
                 )
             # Jump right to the method under test.

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -5,7 +5,6 @@ import logging
 
 from contextlib import ExitStack, contextmanager
 from io import StringIO
-from pathlib import Path
 from pickle import load
 from pkg_resources import resource_filename
 from subprocess import CalledProcessError

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -17,7 +17,7 @@ from ubuntu_image.testing.helpers import (
     EarlyExitLeaveATraceAssertionBuilder, EarlyExitModelAssertionBuilder,
     LogCapture, XXXModelAssertionBuilder, envar)
 from ubuntu_image.testing.nose import NosePlugin
-from unittest import TestCase, skipIf, skip
+from unittest import TestCase, skip, skipIf
 from unittest.mock import call, patch
 
 


### PR DESCRIPTION
First step for [LP: #1641727](https://bugs.launchpad.net/ubuntu-image/+bug/1641727).  This adds a `-O`/`--output-dir` option which names a directory that image files will be written to.  The image files themselves will be called `<volume>.img` where the prefix is taken from the gadget.yaml.