### PR TITLE
Handle /tmp paths better when run as a snap

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,8 @@ ubuntu-image (0.15+17.04ubuntu1) UNRELEASED; urgency=medium
   * Handle structure parts with size of offset < 1MiB.  (LP: #1630709)
   * Allow and ignore any string values in the ``defaults`` section.
     (LP: #1661515)
+  * Handle a couple more cases where ubuntu-image as a snap cannot read
+    from /tmp (model assertions and extra snaps).  (LP: #1663424)
 
  -- Barry Warsaw <barry@ubuntu.com>  Mon, 06 Feb 2017 18:36:02 -0500
 

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ override_dh_install:
 	   debian/ubuntu-image/usr/bin/
 
 override_dh_installman:
-	rst2man ubuntu-image.rst > debian/ubuntu-image.1
+	rst2man ubuntu-image.rst debian/ubuntu-image.1
 	dh_installman
 
 # Run the bare minimum of tests during build.  The majority of the tests will

--- a/devel-coverage.ini
+++ b/devel-coverage.ini
@@ -3,7 +3,7 @@ branch = true
 parallel = true
 omit =
      setup*
-    .tox/*-cov/lib/python*/site-packages/*
+    .tox/*/lib/python*/site-packages/*
     ubuntu_image/tests/*
     ubuntu_image/testing/*
     /usr/lib/python3/dist-packages/*
@@ -11,7 +11,7 @@ omit =
 [paths]
 source =
     ubuntu_image
-    .tox/*-cov/lib/python*/site-packages/ubuntu_image
+    .tox/*/lib/python*/site-packages/ubuntu_image
 
 [report]
 #fail_under = 100

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36}-{nocov,cov,diffcov},qa
+envlist = {py35,py36}-{nocov,cov,diffcov},qa,docs
 #recreate = True
 skip_missing_interpreters = True
 
@@ -36,6 +36,12 @@ rc = --rcfile={[coverage]rcfile}
 basepython = python3
 commands =
     python -m flake8 ubuntu_image
+
+[testenv:docs]
+commands =
+    rst2man ubuntu-image.rst {envtmpdir}/ubuntu-image.1
+whitelist_externals =
+    rst2man
 
 [flake8]
 max-line-length = 79

--- a/ubuntu-image.rst
+++ b/ubuntu-image.rst
@@ -7,7 +7,7 @@ Generate a bootable disk image
 ------------------------------
 
 :Author: Barry Warsaw <barry@ubuntu.com>
-:Date: 2017-01-24
+:Date: 2017-02-13
 :Copyright: 2016-2017 Canonical Ltd.
 :Version: 0.15
 :Manual section: 1
@@ -68,18 +68,16 @@ model_assertion
 -O DIRECTORY, --output-dir DIRECTORY
     Write generated disk image files to this directory.  The files will be
     named after the ``gadget.yaml`` volume names, with ``.img`` suffix
-    appended.  If not given, the current working directory is used.  **NOTE**
-    when run as a snap, this directory cannot be ``/tmp``.  This option
-    replaces, and cannot be used with the deprecated ``--output`` option.
+    appended.  If not given, the current working directory is used.  This
+    option replaces, and cannot be used with, the deprecated ``--output``
+    option.
 
 -o FILENAME, --output FILENAME
     **DEPRECATED** (Use ``--output-dir`` instead.)  The generated disk image
     file.  If not given, the image will be put in a file called ``disk.img``
     in the working directory, in which case, you probably want to specify
     ``--workdir``.  If ``--workdir`` is not given, the image will be written
-    to the current working directory.  **NOTE** when run as a snap,
-    ``ubuntu-image`` refuses to write to ``/tmp`` since this directory is not
-    accessible outside of the snap environment.
+    to the current working directory.
 
 -i SIZE, --image-size SIZE
     The size of the generated disk image files.  If this size is smaller than
@@ -154,6 +152,30 @@ but ``--workdir`` must be given in that case since the state is saved in a
 -r, --resume
     Continue the state machine from the previously saved state.  It is an
     error if there is no previous state.
+
+
+LIMITATIONS
+===========
+
+``ubuntu-image`` may be installed via traditional ``.deb`` or it maybe be
+installed as a snap.  You can tell by running ``ubuntu-image --version`` and
+if the version number has ``+snap`` in the output, you're running it as a
+snap.
+
+It is the case for all snaps that ``/tmp`` outside the snap is not the same as
+``/tmp`` inside the snap, and outside-``/tmp`` is not accessible inside.  This
+means that several options have additional limitations when ``ubuntu-image``
+is run as a snap:
+
+* Outputting images to ``/tmp`` is not possible, therefore you may not use
+  ``/tmp`` in either the ``-O/--output-dir`` or ``-o/--output`` options.
+* Model assertion files may not live in ``/tmp``.
+* Extra snaps (i.e. ``--extra-snaps``) may not refer to snaps in ``/tmp``.
+
+In all these cases, ``ubuntu-image`` will print an error message and exit when
+run as a snap.
+
+None of these limitation apply when ``ubuntu-image`` is installed via ``.deb``.
 
 
 FILES

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -192,7 +192,7 @@ def main(argv=None):
         try:
             state_machine = ModelAssertionBuilder(args)
         except TMPNotReadableFromOutsideSnap as error:
-            print(error.__doc__, file=sys.stderr)
+            print(str(error), file=sys.stderr)
             return 1
     # Run the state machine, either to the end or thru/until the named state.
     try:

--- a/ubuntu_image/builder.py
+++ b/ubuntu_image/builder.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger('ubuntu-image')
 
 
 class TMPNotReadableFromOutsideSnap(Exception):
-    """ubuntu-image snap cannot write images to /tmp"""
+    """/tmp is different from inside and outside a snap."""
 
 
 class ModelAssertionBuilder(State):
@@ -57,10 +57,23 @@ class ModelAssertionBuilder(State):
                     continue
                 path = os.sep.join(path.split(os.sep)[:2])
                 if path == '/tmp':
-                    raise TMPNotReadableFromOutsideSnap
+                    raise TMPNotReadableFromOutsideSnap(
+                        'ubuntu-image snap cannot write images to /tmp')
                 # This path is okay and since it'll take precedence, we're
                 # done checking.
                 break
+            # Check the location of the model assertion.
+            path = os.sep.join(args.model_assertion.split(os.sep)[:2])
+            if path == '/tmp':
+                raise TMPNotReadableFromOutsideSnap(
+                    'ubuntu-image snap cannot read models from /tmp')
+            # Check all the extra snaps.
+            extra_snaps = [] if args.extra_snaps is None else args.extra_snaps
+            for snap_path in extra_snaps:
+                path = os.sep.join(snap_path.split(os.sep)[:2])
+                if path == '/tmp':
+                    raise TMPNotReadableFromOutsideSnap(
+                        'ubuntu-image snap cannot read extra snaps from /tmp')
         self.output_dir = args.output_dir
         self.output = args.output
         # Information passed between states.

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -254,11 +254,12 @@ class TestMainWithModel(TestCase):
         self._resources.enter_context(patch(
             'ubuntu_image.builder.os.getcwd', return_value=output_dir))
         # This directory should not get created.
-        main(('-O', output_dir,
-              # Do not run the full state machine.
-              '-u', 'load_gadget_yaml',
-              self.model_assertion))
-        self.assertFalse(os.path.exists(output_dir))
+        code = main(('-O', output_dir,
+                     # Do not run the full state machine.
+                     '-u', 'load_gadget_yaml',
+                     '/not/tmp/model.assertion'))
+        # Success.
+        self.assertEqual(code, 0, self._stderr.getvalue())
 
     def test_snaps_output_to_tmp(self):
         # LP: 1646968 - Snappy maps /tmp to a private directory so when run as

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -339,7 +339,9 @@ class TestMainWithModel(TestCase):
         self._resources.enter_context(patch(
             'ubuntu_image.__main__.ModelAssertionBuilder',
             DoNothingBuilder))
-        code = main((self.model_assertion, '--extra-snaps', '/tmp/extra.snap'))
+        code = main((self.model_assertion,
+                     '--extra-snaps', '/not/in/tmp/extra.snap',
+                     '--extra-snaps', '/tmp/extra.snap'))
         self.assertEqual(code, 1)
         self.assertEqual(
             self._stderr.getvalue(),

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -327,7 +327,8 @@ class TestMainWithModel(TestCase):
         self._resources.enter_context(patch(
             'ubuntu_image.__main__.ModelAssertionBuilder',
             DoNothingBuilder))
-        code = main(('/tmp/model.assertion',))
+        code = main(('-O', '/not/tmp',
+                     '/tmp/model.assertion',))
         self.assertEqual(code, 1)
         self.assertEqual(
             self._stderr.getvalue(),
@@ -339,9 +340,10 @@ class TestMainWithModel(TestCase):
         self._resources.enter_context(patch(
             'ubuntu_image.__main__.ModelAssertionBuilder',
             DoNothingBuilder))
-        code = main((self.model_assertion,
+        code = main(('-O', '/not/tmp',
                      '--extra-snaps', '/not/in/tmp/extra.snap',
-                     '--extra-snaps', '/tmp/extra.snap'))
+                     '--extra-snaps', '/tmp/extra.snap',
+                     '/not/tmp/model.assertion'))
         self.assertEqual(code, 1)
         self.assertEqual(
             self._stderr.getvalue(),

--- a/xenial-coverage.ini
+++ b/xenial-coverage.ini
@@ -3,7 +3,7 @@ branch = true
 parallel = true
 omit =
      setup*
-    .tox/*-cov/lib/python*/site-packages/*
+    .tox/*/lib/python*/site-packages/*
     ubuntu_image/tests/*
     ubuntu_image/testing/*
     /usr/lib/python3/dist-packages/*
@@ -11,7 +11,7 @@ omit =
 [paths]
 source =
     ubuntu_image
-    .tox/*-cov/lib/python*/site-packages/ubuntu_image
+    .tox/*/lib/python*/site-packages/ubuntu_image
 
 [report]
 #fail_under = 100


### PR DESCRIPTION
[LP: #1663424](https://bugs.launchpad.net/ubuntu-image/+bug/1663424)