### PR TITLE
Don't install an unusable global flake8 extension.  (LP: #1631156)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ ubuntu-image (1.0+17.04ubuntu1) UNRELEASED; urgency=medium
 
   * Exit with a console message instead of crashing when the contents of a
     partition does not fit within the specified size.  (LP: #1666580)
+  * Don't install an unusable global flake8 extension.  (LP: #1631156)
 
  -- Barry Warsaw <barry@ubuntu.com>  Wed, 22 Feb 2017 11:30:01 -0500
 

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,6 @@ export PYBUILD_NAME=ubuntu-image
 export UBUNTU_IMAGE_TESTS_NO_NETWORK=1
 export pkgversion=$(shell dpkg-parsechangelog --show-field version)
 
-
 %:
 	dh $@ --with=python3 --buildsystem=pybuild
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 
 try:
@@ -37,6 +38,7 @@ def require_python(minimum):
                 major, minor, micro, hex(release)[2:]))
         sys.exit(1)
 
+
 require_python(0x30500f0)
 
 
@@ -49,6 +51,17 @@ else:
         # --version` can display it.
         with open('ubuntu_image/version.txt', 'w', encoding='utf-8') as outfp:
             print(__version__, file=outfp)
+
+
+# LP: #1631156 - We want the flake8 entry point for all testing purposes, but
+# we do not want to install an ubuntu_image.egg-info/entry_points.txt file
+# with the flake8 entry point, since this will globally break other packages.
+# Unfortunately we cannot adopt flufl.testing since that's not available
+# before Ubuntu 17.04, and we still need to support 16.04 LTS.
+entry_points = dict()
+if os.environ.get('UBUNTU_IMAGE_BUILD_FOR_TESTING', False):
+    entry_points['flake8.extension'] = [
+        'B4 = ubuntu_image.testing.flake8:ImportOrder']
 
 
 setup(
@@ -65,9 +78,7 @@ setup(
         ],
     include_package_data=True,
     scripts=['ubuntu-image'],
-    entry_points={
-        'flake8.extension': ['B4 = ubuntu_image.testing.flake8:ImportOrder'],
-        },
+    entry_points=entry_points,
     license='GPLv3',
     classifiers=(
         'Development Status :: 3 - Alpha',

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ passenv =
     UBUNTU_IMAGE_*
     *_proxy
 setenv =
+    UBUNTU_IMAGE_BUILD_FOR_TESTING=1
     cov: COVERAGE_PROCESS_START={[coverage]rcfile}
     cov: COVERAGE_OPTIONS="-p"
     cov: COVERAGE_FILE={toxinidir}/.coverage

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -429,6 +429,8 @@ class TestMainWithModel(TestCase):
         main(('--workdir', workdir, '--resume'))
         self.assertTrue(os.path.exists(os.path.join(workdir, 'success')))
 
+    @skipIf('UBUNTU_IMAGE_TESTS_NO_NETWORK' in os.environ,
+            'Cannot run this test without network access')
     def test_does_not_fit(self):
         # The contents of a structure is too large for the image size.
         workdir = self._resources.enter_context(TemporaryDirectory())


### PR DESCRIPTION
[LP: #1631156](https://bugs.launchpad.net/ubuntu-image/+bug/1631156)