### PR TITLE
Make snap.sh test run only on github PRs.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-image (1.2+17.10ubuntu1) UNRELEASED; urgency=medium
+ubuntu-image (1.1+17.10ubuntu2) UNRELEASED; urgency=medium
 
   * Only run the snap.sh test on github PRs as it doesn't make sense to run it
     as part of regular deb package migration.  (LP: #1704979)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-image (1.2+17.10ubuntu1) UNRELEASED; urgency=medium
+
+  * Only run the snap.sh test on github PRs as it doesn't make sense to run it
+    as part of regular deb package migration.  (LP: #1704979)
+
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Wed, 19 Jul 2017 15:31:06 +0200
+
 ubuntu-image (1.1+17.10ubuntu1) artful; urgency=medium
 
   [ Łukasz 'sil2100' Zemczak ]

--- a/debian/tests/snap.sh
+++ b/debian/tests/snap.sh
@@ -1,3 +1,5 @@
+[ -z "$UPSTREAM_PULL_REQUEST" ] && ( echo "Skipping test, not ran as part of a pull request."; exit 0; )
+
 sudo snap install core
 
 snapcraft


### PR DESCRIPTION
As per some discussion, snap.sh is a test-case that makes sense when run on PRs and some local testing as it tests ubuntu-image snapcraftability, but for debian package migration it is not really a good idea. There is no merit in checking if we can build the snap out of the source coming from the given debian package (that's a very twisted way of thinking). At least it shouldn't really stop the package from migrating.

LP: #1704979