### PR TITLE
Add two subcommands(snap, classic) support in command line.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ stage
 coverage.xml
 diffcov.html
 demo/model.assertion
+*.model
+.tox

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-image (1.1+17.10ubuntu4) UNRELEASED; urgency=medium
+
+  * In order to support classic image creation, we add two subcommands(snap,classic)
+    support in this tool.
+
+ -- Gary Wang <gary.wang@canonical.com>  Tue, 29 Aug 2017 20:02:57 +0800
+
 ubuntu-image (1.1+17.10ubuntu3) artful; urgency=medium
 
   * Only run the snap.sh test on github PRs as it doesn't make sense to run it

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -104,7 +104,7 @@ class SizeAction(argparse.Action):
 def get_modified_args(subparser, default_subcommand, argv):
     for arg in argv:
         # skip global help option
-        if arg in ['-h', '--help']:
+        if arg in ['-h', '--help', '-v', '--version']:
             break
     else:
         for sp_name in subparser._name_parser_map.keys():
@@ -123,9 +123,6 @@ def get_modified_args(subparser, default_subcommand, argv):
 
 def add_common_args(subcommand):
     common_group = subcommand.add_argument_group(_('Common options'))
-    common_group.add_argument(
-        '--version', action='version',
-        version='{} {}'.format(PROGRAM, __version__))
     common_group.add_argument(
         '-d', '--debug',
         default=False, action='store_true',
@@ -203,6 +200,9 @@ def parseargs(argv=None):
         prog=PROGRAM,
         description=_('Generate a bootable disk image.'),
         formatter_class=SimpleHelpFormatter)
+    parser.add_argument(
+        '--version', action='version',
+        version='{} {}'.format(PROGRAM, __version__))
 
     # create two subcommands, "snap" and "classic"
     subparser = parser.add_subparsers(title=_('Command'), dest='cmd')

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -21,6 +21,12 @@ PROGRAM = 'ubuntu-image'
 
 
 class SimpleHelpFormatter(argparse.HelpFormatter):
+    """SimpleHelpFormatter for generating intuitive help infomation.
+
+    It uses fixed-width indentation for each sub command, options.
+    It makes some tweaks on help information layout and removes
+    redundant symbol for sub-commands prompt.
+    """
     def add_usage(self, usage, actions, groups, prefix=None):
         # only show main usage when no subcommand is provided.
         if prefix is None:
@@ -118,6 +124,9 @@ def get_modified_args(subparser, default_subcommand, argv):
 def add_common_args(subcommand):
     common_group = subcommand.add_argument_group(_('Common options'))
     common_group.add_argument(
+        '--version', action='version',
+        version='{} {}'.format(PROGRAM, __version__))
+    common_group.add_argument(
         '-d', '--debug',
         default=False, action='store_true',
         help=_('Enable debugging output'))
@@ -194,10 +203,6 @@ def parseargs(argv=None):
         prog=PROGRAM,
         description=_('Generate a bootable disk image.'),
         formatter_class=SimpleHelpFormatter)
-
-    parser.add_argument(
-        '--version', action='version',
-        version='{} {}'.format(PROGRAM, __version__))
 
     # create two subcommands, "snap" and "classic"
     subparser = parser.add_subparsers(title=_('Command'), dest='cmd')
@@ -277,7 +282,6 @@ def parseargs(argv=None):
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
-
     # The model assertion argument is required unless --resume is given, in
     # which case it cannot be given.
     # if args.cmd == 'snap':

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -1,6 +1,7 @@
 """Allows the package to be run with `python3 -m ubuntu_image`."""
 
 import os
+import re
 import sys
 import logging
 import argparse
@@ -12,12 +13,53 @@ from ubuntu_image.builder import DoesNotFit, ModelAssertionBuilder
 from ubuntu_image.helpers import as_size
 from ubuntu_image.i18n import _
 from ubuntu_image.parser import GadgetSpecificationError
+from subprocess import Popen, PIPE
 
 
 _logger = logging.getLogger('ubuntu-image')
 
 
 PROGRAM = 'ubuntu-image'
+
+
+class SimpleHelpFormatter(argparse.HelpFormatter):
+    def add_usage(self, usage, actions, groups, prefix=None):
+        # only show main usage when no subcommand is provided.
+        if prefix is None:
+            prefix = 'Usage: '
+        if len(actions) != 0:
+            usage="""
+  {prog} [OPTIONS] COMMAND [ARGS]...
+  {prog} COMMAND --help """. format(prog=PROGRAM)
+        else:
+            usage="""
+  {prog} [OPTIONS] """. format(prog=PROGRAM)
+
+        return super(SimpleHelpFormatter, self).add_usage(
+            usage, actions, groups, prefix)
+    def _format_action(self, action):
+        if type(action) == argparse._SubParsersAction:
+            # calculate the subcommand max length
+            subactions = action._get_subactions()
+            invocations = [self._format_action_invocation(a) for a in subactions]
+            self._subcommand_max_length = max(len(i) for i in invocations)
+
+        if type(action) == argparse._SubParsersAction._ChoicesPseudoAction:
+            # format subcommand help line
+            subcommand = self._format_action_invocation(action)
+            help_text = ""
+            if action.help:
+                help_text = self._expand_help(action)
+            return "  {:{width}}\t\t{} \n".format(subcommand, help_text,
+                    width=self._subcommand_max_length)
+        elif type(action) == argparse._SubParsersAction:
+            # eliminate subcommand choices line {cmd1, cmd2}
+            msg = ''
+            for subaction in action._get_subactions():
+                msg += self._format_action(subaction)
+            return msg
+        else:
+            return super(SimpleHelpFormatter, self)._format_action(action)
 
 
 class SizeAction(argparse.Action):
@@ -56,22 +98,71 @@ class SizeAction(argparse.Action):
         # For display purposes.
         namespace.given_image_size = values
 
+def get_host_arch():
+    process = Popen(["dpkg", "--print-architecture"], stdout=PIPE)
+    (output, err) = process.communicate()
+    exit_code = process.wait()
+    return output.decode('ascii').strip() if exit_code == 0 else None
+
+def get_modified_arguments(self, default_subcommand, argv):
+    subparser_found = False
+    for arg in argv:
+        # skip global help option and state machine resume option, no need
+        # to provide model_assertion file if -r option is not specified
+
+        if arg in ['-h', '--help',
+                   '-r', '--resume']:
+            break
+    else:
+        all_args=' '.join(argv)
+        for x in self._subparsers._actions:
+            if not isinstance(x, argparse._SubParsersAction):
+                continue
+            for sp_name in x._name_parser_map.keys():
+                if sp_name in argv:
+                    subparser_found = True # if default subcommand is provided.
+        if not subparser_found:
+            print('Warning: for backwards compatibility, `ubuntu-image` fallbacks to '
+                  '`ubuntu-image snap` if no subcommand is provided',
+                  file=sys.stderr)
+
+            # re-arrange snap specific args for backwards compatibility.
+            snap_args_pattern=r'(?:--channel|-c|--extra-snaps|--cloud-init)\s{1}\S*'
+            match_args=re.findall(snap_args_pattern, all_args)
+            snap_args = [arg for arg_pair in match_args for arg in arg_pair.split()]
+
+            # remove match args and only keep global options.
+            all_args=re.sub(snap_args_pattern, '', all_args)
+
+            # and insert 'snap' subcommand at proper position.
+            # put snap specific args after `snap` subcommand.
+            new_argv = all_args.split()
+            insert_pos = len(new_argv)
+            new_argv.insert(insert_pos - 1, default_subcommand)
+            new_argv[insert_pos:insert_pos] = snap_args
+
+            return new_argv
+    return argv
 
 def parseargs(argv=None):
     parser = argparse.ArgumentParser(
         prog=PROGRAM,
         description=_('Generate a bootable disk image.'),
-        )
+        formatter_class=SimpleHelpFormatter)
+
     parser.add_argument(
         '--version', action='version',
         version='{} {}'.format(PROGRAM, __version__))
-    # Common options.
+
+    # create two subcommands, "snap" and "classic"
+    subparser = parser.add_subparsers(title=_('Command'), dest='cmd')
+    snap_cmd = subparser.add_parser('snap',
+        help=_("""Create snap-based Ubuntu Core image."""))
+    classic_cmd = subparser.add_parser('classic',
+        help=_("""Create debian-based Ubuntu Classic image."""))
+    argv = parser.get_modified_arguments('snap', argv)
+
     common_group = parser.add_argument_group(_('Common options'))
-    common_group.add_argument(
-        'model_assertion', nargs='?',
-        help=_("""Path to the model assertion file.  This argument must be
-        given unless the state machine is being resumed, in which case it
-        cannot be given."""))
     common_group.add_argument(
         '-d', '--debug',
         default=False, action='store_true',
@@ -107,24 +198,7 @@ def parseargs(argv=None):
         disk image file.  If not given, the image will be put in a file called
         disk.img in the working directory (in which case, you probably want to
         specify -w)."""))
-    # Snap-based image options.
-    snap_group = parser.add_argument_group(
-        _('Image contents options'),
-        _("""Additional options for defining the contents of snap-based
-        images."""))
-    snap_group.add_argument(
-        '--extra-snaps',
-        default=None, action='append',
-        help=_("""Extra snaps to install.  This is passed through to `snap
-        prepare-image`."""))
-    snap_group.add_argument(
-        '--cloud-init',
-        default=None, metavar='USER-DATA-FILE',
-        help=_('cloud-config data to be copied to the image'))
-    snap_group.add_argument(
-        '-c', '--channel',
-        default=None,
-        help=_('The snap channel to use'))
+
     # State machine options.
     inclusive_state_group = parser.add_argument_group(
         _('State machine options'),
@@ -158,15 +232,80 @@ def parseargs(argv=None):
         default=False, action='store_true',
         help=_("""Continue the state machine from the previously saved state.
         It is an error if there is no previous state."""))
+
+    # Snap-based image options.
+    snap_cmd.add_argument(
+        'model_assertion', nargs='?',
+        help=_("""Path to the model assertion file.  This argument must be
+        given unless the state machine is being resumed, in which case it
+        cannot be given."""))
+    snap_cmd.add_argument(
+        '--extra-snaps',
+        default=None, action='append',
+        help=_("""Extra snaps to install.  This is passed through to `snap
+        prepare-image`."""))
+    snap_cmd.add_argument(
+        '--cloud-init',
+        default=None, metavar='USER-DATA-FILE',
+        help=_('cloud-config data to be copied to the image'))
+    snap_cmd.add_argument(
+        '-c', '--channel',
+        default=None,
+        help=_('The snap channel to use'))
+
+    # Classic-based image options.
+    classic_cmd.add_argument(
+        'project', nargs='?', metavar='PROJECT',
+        help=_("""Project name to be specified to livecd-rootfs."""))
+    classic_cmd.add_argument(
+        'suite', nargs='?', metavar='SUITE',
+        help=_("""Distribution name to be specified to livecd-rootfs."""))
+    classic_cmd.add_argument(
+        'gadget-tree', nargs='?', metavar='GADGET-TREE',
+        help=_("""Gadget tree"""))
+    classic_cmd.add_argument(
+        '-a', '--arch',
+        default=get_host_arch(), metavar='CPU-ARCHITECTURE',
+        help=_("""CPU architecture to be specified to livecd-rootfs.
+        default value is builder arch."""))
+    classic_cmd.add_argument(
+        '-s', '--subarch',
+        default=None, metavar='SUBARCH',
+        help=_("""Sub architecture to be specified to livecd-rootfs."""))
+    classic_cmd.add_argument(
+        '-p', '--proposed',
+        default=None, metavar='PROPOSED',
+        help=_("""Proposed repo to install, This is passed through to
+        livecd-rootfs."""))
+    classic_cmd.add_argument(
+        '--subproject',
+        default=None, metavar='SUBPROJECT',
+        help=_("""Sub project name to be specified to livecd-rootfs."""))
+    classic_cmd.add_argument(
+        '--image-format',
+        default='img',
+        help=_("""Image format to be specified to livecd-rootfs."""))
+    classic_cmd.add_argument(
+        '--extra-ppas',
+        default=None, action='append',
+        help=_("""Extra ppas to install. This is passed through to
+        livecd-rootfs."""))
+
     args = parser.parse_args(argv)
+
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
-    # The model assertion argument is required unless --resume is given, in
-    # which case it cannot be given.
-    if args.resume and args.model_assertion:
-        parser.error('model assertion is not allowed with --resume')
-    if not args.resume and args.model_assertion is None:
-        parser.error('model assertion is required')
+
+    if args.cmd == 'snap' :
+        # The model assertion argument is required unless --resume is given, in
+        # which case it cannot be given.
+        if args.resume and args.model_assertion:
+            parser.error('model assertion is not allowed with --resume')
+        if not args.resume and args.model_assertion is None:
+            parser.error('model assertion is required')
+    elif args.cmd == 'classic' :
+        print ('classic::  ', args.arch)
+
     if args.resume and args.workdir is None:
         parser.error('--resume requires --workdir')
     # --until and --thru can take an int.
@@ -180,8 +319,12 @@ def parseargs(argv=None):
               file=sys.stderr)
     return args
 
+argparse.ArgumentParser.get_modified_arguments = get_modified_arguments
 
 def main(argv=None):
+    if argv == None:
+        argv = sys.argv[1:]
+
     args = parseargs(argv)
     if args.workdir:
         os.makedirs(args.workdir, exist_ok=True)
@@ -192,8 +335,13 @@ def main(argv=None):
         with open(pickle_file, 'rb') as fp:
             state_machine = load(fp)
         state_machine.workdir = args.workdir
-    else:
+    elif args.cmd == 'snap':
         state_machine = ModelAssertionBuilder(args)
+    '''
+    elif args.cmd == 'classic':
+        sys.exit(0)
+        state_machine = ClassicBuilder(args)
+    '''
     # Run the state machine, either to the end or thru/until the named state.
     try:
         if args.thru:

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -103,8 +103,8 @@ class SizeAction(argparse.Action):
 
 def get_modified_args(subparser, default_subcommand, argv):
     for arg in argv:
-        # skip global help option
-        if arg in ['-h', '--help', '-v', '--version']:
+        # skip global help and version option
+        if arg in ['-h', '--help', '--version']:
             break
     else:
         for sp_name in subparser._name_parser_map.keys():

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 from pickle import dump, load
 from ubuntu_image import __version__
 from ubuntu_image.builder import DoesNotFit, ModelAssertionBuilder
-from ubuntu_image.helpers import as_size, run
+from ubuntu_image.helpers import as_size, get_host_arch, get_host_distro
 from ubuntu_image.i18n import _
 from ubuntu_image.parser import GadgetSpecificationError
 
@@ -93,11 +93,6 @@ class SizeAction(argparse.Action):
         setattr(namespace, self.dest, sizes)
         # For display purposes.
         namespace.given_image_size = values
-
-
-def get_host_arch():
-    proc = run('dpkg --print-architecture', check=False)
-    return proc.stdout.strip() if proc.returncode == 0 else None
 
 
 def get_modified_args(subparser, default_subcommand, argv):
@@ -239,32 +234,35 @@ def parseargs(argv=None):
 
     # Classic-based image options.
     classic_cmd.add_argument(
-        'project', nargs='?', metavar='PROJECT',
+        'gadget_tree', nargs='?',
+        help=_("""Gadget tree.  This is a tree equivalent to an unpacked
+        gadget snap at core image build time."""))
+    classic_cmd.add_argument(
+        '-p', '--project',
+        default='ubuntu-cpc', metavar='PROJECT',
         help=_("""Project name to be specified to livecd-rootfs."""))
     classic_cmd.add_argument(
-        'suite', nargs='?', metavar='SUITE',
+        '-s', '--suite',
+        default=get_host_distro(), metavar='SUITE',
         help=_("""Distribution name to be specified to livecd-rootfs."""))
-    classic_cmd.add_argument(
-        'gadget-tree', nargs='?', metavar='GADGET-TREE',
-        help=_("""Gadget tree"""))
     classic_cmd.add_argument(
         '-a', '--arch',
         default=get_host_arch(), metavar='CPU-ARCHITECTURE',
         help=_("""CPU architecture to be specified to livecd-rootfs.
         default value is builder arch."""))
     classic_cmd.add_argument(
-        '-s', '--subarch',
-        default=None, metavar='SUBARCH',
-        help=_("""Sub architecture to be specified to livecd-rootfs."""))
-    classic_cmd.add_argument(
-        '-p', '--proposed',
-        default=None, metavar='PROPOSED',
-        help=_("""Proposed repo to install, This is passed through to
-        livecd-rootfs."""))
-    classic_cmd.add_argument(
         '--subproject',
         default=None, metavar='SUBPROJECT',
         help=_("""Sub project name to be specified to livecd-rootfs."""))
+    classic_cmd.add_argument(
+        '--subarch',
+        default=None, metavar='SUBARCH',
+        help=_("""Sub architecture to be specified to livecd-rootfs."""))
+    classic_cmd.add_argument(
+        '--with-proposed',
+        default=False, action='store_true',
+        help=_("""Proposed repo to install, This is passed through to
+        livecd-rootfs."""))
     classic_cmd.add_argument(
         '--image-format',
         default='img',

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -101,7 +101,7 @@ class SizeAction(argparse.Action):
 
 
 def get_host_arch():
-    proc = run('dpkg --print-architecture')
+    proc = run('dpkg --print-architecture', check=False)
     return proc.stdout.strip() if proc.returncode == 0 else None
 
 

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -78,6 +78,16 @@ def as_size(size, min=0, max=None):
     return value
 
 
+def get_host_arch():
+    proc = run('dpkg --print-architecture', check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def get_host_distro():
+    proc = run('lsb_release -c -s', check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
 def run(command, *, check=True, **args):
     runnable_command = (
         command.split() if isinstance(command, str) and 'shell' not in args

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -11,7 +11,8 @@ from subprocess import run as subprocess_run
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from types import SimpleNamespace
 from ubuntu_image.helpers import (
-    GiB, MiB, as_bool, as_size, mkfs_ext4, run, snap, sparse_copy)
+     GiB, MiB, as_bool, as_size, get_host_arch, get_host_distro,
+     mkfs_ext4, run, snap, sparse_copy)
 from ubuntu_image.testing.helpers import LogCapture
 from unittest import TestCase
 from unittest.mock import patch
@@ -156,6 +157,12 @@ class TestHelpers(TestCase):
         for value in {'YES', 'tRUE', '1', 'eNaBlE', 'enabled'}:
             self.assertTrue(as_bool(value), value)
         self.assertRaises(ValueError, as_bool, 'anything else')
+
+    def test_get_host_arch(self):
+        self.assertIsNotNone(get_host_arch())
+
+    def test_get_host_distro(self):
+        self.assertIsNotNone(get_host_distro())
 
     def test_sparse_copy(self):
         with ExitStack() as resources:

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -121,8 +121,10 @@ class TestMain(TestCase):
             main(('--help',))
         self.assertEqual(cm.exception.code, 0)
         lines = self._stdout.getvalue().splitlines()
-        self.assertTrue(lines[0].startswith('usage: ubuntu-image'),
+        self.assertTrue(lines[0].startswith('Usage'),
                         lines[0])
+        self.assertTrue(lines[1].startswith('  ubuntu-image'),
+                        lines[1])
 
     def test_debug(self):
         with ExitStack() as resources:

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -51,16 +51,18 @@ class TestGetModifiedArgs(TestCase):
         self.assertEqual(['--help'], argv)
 
     def test_image_without_subcommand(self):
-        parser = argparse.ArgumentParser(add_help=False)
-        # create one subcommand, "snap"
-        subparser = parser.add_subparsers(dest='cmd')
-        subparser.add_parser('snap')
-        argv = get_modified_args(
-                subparser, 'snap',
-                ['-o', 'abc.img', '-i', '45', 'model.assertion'])
-        self.assertEqual(
-                ['snap', '-o', 'abc.img', '-i', '45', 'model.assertion'],
-                argv)
+        stderr = StringIO()
+        with patch('sys.stderr', stderr):
+            parser = argparse.ArgumentParser(add_help=False)
+            # create one subcommand, "snap"
+            subparser = parser.add_subparsers(dest='cmd')
+            subparser.add_parser('snap')
+            argv = get_modified_args(
+                    subparser, 'snap',
+                    ['-o', 'abc.img', '-i', '45', 'model.assertion'])
+            self.assertEqual(
+                    ['snap', '-o', 'abc.img', '-i', '45', 'model.assertion'],
+                    argv)
 
     def test_image_with_subcommand(self):
         parser = argparse.ArgumentParser(add_help=False)
@@ -75,17 +77,19 @@ class TestGetModifiedArgs(TestCase):
                 argv)
 
     def test_image_with_multiple_subcommand(self):
-        parser = argparse.ArgumentParser(add_help=False)
-        # create two subcommands, "snap" and "classic"
-        subparser = parser.add_subparsers(dest='cmd')
-        subparser.add_parser('snap')
-        subparser.add_parser('classic')
-        argv = get_modified_args(
-                subparser, 'classic',
-                ['-d', '-o', 'pc_amd64.img', 'model.assertion'])
-        self.assertEqual(
-                ['classic', '-d', '-o', 'pc_amd64.img', 'model.assertion'],
-                argv)
+        stderr = StringIO()
+        with patch('sys.stderr', stderr):
+            parser = argparse.ArgumentParser(add_help=False)
+            # create two subcommands, "snap" and "classic"
+            subparser = parser.add_subparsers(dest='cmd')
+            subparser.add_parser('snap')
+            subparser.add_parser('classic')
+            argv = get_modified_args(
+                    subparser, 'classic',
+                    ['-d', '-o', 'pc_amd64.img', 'model.assertion'])
+            self.assertEqual(
+                    ['classic', '-d', '-o', 'pc_amd64.img', 'model.assertion'],
+                    argv)
 
 
 class TestParseArgs(TestCase):
@@ -95,9 +99,11 @@ class TestParseArgs(TestCase):
         self.assertEqual(args.given_image_size, '45')
 
     def test_image_size_option_bytes_without_subcommand(self):
-        args = parseargs(['--image-size', '45', 'model.assertion'])
-        self.assertEqual(args.image_size, 45)
-        self.assertEqual(args.given_image_size, '45')
+        stderr = StringIO()
+        with patch('sys.stderr', stderr):
+            args = parseargs(['--image-size', '45', 'model.assertion'])
+            self.assertEqual(args.image_size, 45)
+            self.assertEqual(args.given_image_size, '45')
 
     def test_image_size_option_suffixes(self):
         args = parseargs(['snap', '--image-size', '45G', 'model.assertion'])

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -11,7 +11,7 @@ from pkg_resources import resource_filename
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from ubuntu_image.__main__ import main, parseargs, get_modified_args
+from ubuntu_image.__main__ import get_modified_args, main, parseargs
 from ubuntu_image.helpers import GiB, MiB
 from ubuntu_image.testing.helpers import (
     CrashingModelAssertionBuilder, DoNothingBuilder,

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -77,9 +77,13 @@ class TestParseArgs(TestCase):
         stderr = StringIO()
         with patch('sys.stderr', stderr):
             parseargs(['-o', '/tmp/disk.img', 'model.assertion'])
+        lines = stderr.getvalue().splitlines()
+        self.assertTrue(
+                lines[0].startswith('Warning: for backwards compatibility'),
+                lines[0])
         self.assertEqual(
-            stderr.getvalue(),
-            '-o/--output is deprecated; use -O/--output-dir instead\n')
+                lines[1],
+                '-o/--output is deprecated; use -O/--output-dir instead')
 
     def test_multivolume_image_size(self):
         args = parseargs(['-i', '0:4G,sdcard:2G,1:4G', 'model.assertion'])

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -277,16 +277,8 @@ class TestMain(TestCase):
 
     def test_with_none(self):
         with self.assertRaises(SystemExit) as cm:
-            main((None))    # code coverage __main__.py 345-346
+            main((None))    # code coverage __main__.py 308-309
         self.assertEqual(cm.exception.code, 2)
-        lines = self._stderr.getvalue().splitlines()
-        self.assertTrue(
-                lines[0].startswith('Warning: for backwards compatibility'),
-                lines[0])
-        self.assertTrue(lines[1], 'Usage:')
-        self.assertEqual(
-                lines[2],
-                '  ubuntu-image COMMAND [OPTIONS]...')
 
     def test_snap_subcommand_help(self):
         with self.assertRaises(SystemExit) as cm:


### PR DESCRIPTION
1.Common arguments shared between both subcommands.
2.For backwards compatibility, whenever ubuntu-image is called
  without a subcommand issue a warning and default to 'ubuntu-image snap'.
3.Supported 'ubuntu-image classic' with a bunch of options.