### PR TITLE
Create the classic image and manifest file with the proper user.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ passenv =
     PYTHON*
     UBUNTU_IMAGE_*
     *_proxy
+    USER
 setenv =
     UBUNTU_IMAGE_BUILD_FOR_TESTING=1
     cov: COVERAGE_PROCESS_START={[coverage]rcfile}

--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -192,6 +192,12 @@ class ClassicBuilder(AbstractImageBuilderState):
             self._populate_one_bootfs(name, volume)
         super().populate_bootfs_contents()
 
+    def make_disk(self):
+        super().make_disk()
+        user = os.environ['SUDO_USER']
+        run('chown {}:{} {}/*.img'.format(user, user, self.output_dir),
+            shell=True, check=False)
+
     def generate_manifests(self):
         # After the images are built, we would also like to have some image
         # manifests exported so that one can easily check what packages have
@@ -212,4 +218,7 @@ class ClassicBuilder(AbstractImageBuilderState):
                 for line in tmpfile:
                     if not any(word in line for word in deprecated_words):
                         manifest.write(line)
+        user = os.environ['SUDO_USER']
+        run('chown {}:{} {}'.format(user, user, manifest_path),
+            check=False)
         super().generate_manifests()


### PR DESCRIPTION
We create the classic image as root, which causes the final classic image and manifest file being owned by root. It makes more sense that these two final generated files are owned by the login user rather than root after the image creation.