### PR TITLE
Utilize the existing environment variable for a single rootfs generation.

### DIFF
--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -90,7 +90,7 @@ class ClassicBuilder(AbstractImageBuilderState):
             if self.args.extra_ppas is not None:
                 env['EXTRA_PPAS'] = self.args.extra_ppas
             # Only genereate a single rootfs tree for classic image creation.
-            env['GENERATE_ROOTFS_ONLY'] = '1'
+            env['IMAGEFORMAT'] = 'none'
             live_build(self.unpackdir, env)
         except CalledProcessError:
             if self.args.debug:


### PR DESCRIPTION
For the record, per the suggestion by Steve, it's better to use the existing environment variable (IMAGEFORMAT=none) to generate a single rootfs. 
We need to track the following MP on launchpad and don't release the ubuntu image snap until everything is ready.
https://code.launchpad.net/~gary-wzl77/livecd-rootfs/classic_image_creation/+merge/330211