### PR TITLE
Make the --project argument required when building classic images.

### DIFF
--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -243,11 +243,11 @@ def parseargs(argv=None):
     classic_cmd.add_argument(
         'gadget_tree', nargs='?',
         help=_("""Gadget tree.  This is a tree equivalent to an unpacked
-        gadget snap at core image build time. It could be either a local
+        gadget snap at core image build time.  It could be either a local
         snap project or a snap-based git repository."""))
     classic_cmd.add_argument(
         '-p', '--project',
-        default='ubuntu-cpc', metavar='PROJECT',
+        default=None, metavar='PROJECT',
         help=_("""Project name to be specified to livecd-rootfs."""))
     classic_cmd.add_argument(
         '-s', '--suite',
@@ -290,8 +290,11 @@ def parseargs(argv=None):
     else:
         if args.resume and args.gadget_tree:
             parser.error('gadget tree is not allowed with --resume')
-        if not args.resume and args.gadget_tree is None:
-            parser.error('gadget tree is required')
+        if not args.resume:   # pragma: no branch
+            if args.gadget_tree is None:
+                parser.error('gadget tree is required')
+            elif args.project is None:
+                parser.error('project is required')
     if args.resume and args.workdir is None:
         parser.error('--resume requires --workdir')
     # --until and --thru can take an int.

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -184,6 +184,33 @@ class TestParseArgs(TestCase):
         self.assertListEqual(
             args.hooks_directory, ['/foo/bar', '/foo/baz', '~/bar'])
 
+    def test_classic_gadget_tree_required(self):
+        stderr = StringIO()
+        with patch('sys.stderr', stderr):
+            self.assertRaises(SystemExit,
+                              parseargs,
+                              ['classic'])
+        line = stderr.getvalue()
+        self.assertIn('gadget tree is required', line)
+
+    def test_classic_project_required(self):
+        stderr = StringIO()
+        with patch('sys.stderr', stderr):
+            self.assertRaises(SystemExit,
+                              parseargs,
+                              ['classic', 'tree_url'])
+        line = stderr.getvalue()
+        self.assertIn('project is required', line)
+
+    def test_classic_resume_gadget_tree(self):
+        stderr = StringIO()
+        with patch('sys.stderr', stderr):
+            self.assertRaises(SystemExit,
+                              parseargs,
+                              ['classic', '--resume', 'tree_url'])
+        line = stderr.getvalue()
+        self.assertIn('gadget tree is not allowed with --resume', line)
+
 
 class TestMain(TestCase):
     def setUp(self):
@@ -540,6 +567,7 @@ class TestMainWithGadget(TestCase):
             patch('ubuntu_image.classic_builder.check_root_privilege'))
         main(('classic', '--until', 'prepare_image',
               '--workdir', workdir,
+              '--project', 'ubuntu-cpc',
               self.classic_gadget_tree))
         self.assertFalse(os.path.exists(os.path.join(workdir, 'success')))
         main(('--workdir', workdir, '--resume'))
@@ -578,6 +606,7 @@ class TestMainWithGadget(TestCase):
         mock = self._resources.enter_context(patch(
             'ubuntu_image.__main__._logger.error'))
         code = main(('classic', '--workdir', workdir,
+                     '--project', 'ubuntu-cpc',
                      self.classic_gadget_tree))
         self.assertEqual(code, 1)
         self.assertFalse(os.path.exists(os.path.join(workdir, 'success')))


### PR DESCRIPTION
Otherwise this can cause some confusion on what kind of an image has been built. There is no 'universal' image we should be building.