### PR TITLE
export GIT_SSH_COMMAND in git.custom_environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ diffcov.html
 demo/model.assertion
 *.model
 .tox
+snap
+*.snap

--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -48,10 +48,10 @@ class ClassicBuilder(AbstractImageBuilderState):
 
     def prepare_gadget_tree(self):
         try:
-            git_ssh_identity_file = os.path.expanduser('~/.ssh/id_rsa')
-            git_ssh_cmd = 'ssh -i {}'.format(git_ssh_identity_file)
             gadget_dst = os.path.join(self.unpackdir, 'gadget_repo')
             if urlparse(self.gadget_tree).scheme != "":
+                git_ssh_identity_file = os.path.expanduser('~/.ssh/id_rsa')
+                git_ssh_cmd = 'ssh -i {}'.format(git_ssh_identity_file)
                 git.Repo.clone_from(self.gadget_tree, gadget_dst,
                                     progress=GitProgress(),
                                     env=dict(GIT_SSH_COMMAND=git_ssh_cmd))

--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -48,10 +48,13 @@ class ClassicBuilder(AbstractImageBuilderState):
 
     def prepare_gadget_tree(self):
         try:
+            git_ssh_identity_file = os.path.expanduser('~/.ssh/id_rsa')
+            git_ssh_cmd = 'ssh -i {}'.format(git_ssh_identity_file)
             gadget_dst = os.path.join(self.unpackdir, 'gadget_repo')
             if urlparse(self.gadget_tree).scheme != "":
                 git.Repo.clone_from(self.gadget_tree, gadget_dst,
-                                    progress=GitProgress())
+                                    progress=GitProgress(),
+                                    env=dict(GIT_SSH_COMMAND=git_ssh_cmd))
             else:
                 shutil.copytree(self.gadget_tree, gadget_dst)
             # generate unpacked gadget snap


### PR DESCRIPTION
When fetching the source code of gadget tree from a private repo
on launchpad, ssh connection is required. We need to export
GIT_SSH_COMMAND variable in git.custom_environment to make it work.
Fix LP: 1733794