### PR TITLE
Enable defining the livecd-rootfs config dir through an environment variable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ ubuntu-image (1.3+18.04ubuntu1) UNRELEASED; urgency=medium
 
   * Remove the snapcraft dependency by moving the gadget tree priming step away
     from ubuntu-image.  (LP: #1734655)
+  * Add support for defining the livecd-rootfs configuration path through
+    an environment variable.  (LP: #1734949)
 
  -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Mon, 27 Nov 2017 11:12:08 +0100
 

--- a/ubuntu-image.rst
+++ b/ubuntu-image.rst
@@ -259,6 +259,13 @@ The following environment variables are recognized by ``ubuntu-image``.
     ``<workdir>/unpack`` directory after the ``snap prepare-image`` subcommand
     has run will be copied here.
 
+``UBUNTU_IMAGE_LIVECD_ROOTFS_AUTO_PATH``
+    ``ubuntu-image`` uses ``livecd-rootfs`` configuration files for its
+    ``live-build`` runs.  If this variable is set, ``ubuntu-image`` will use
+    the configuration files from the selected path for its auto configuration.
+    Otherwise it will attempt to localize ``livecd-rootfs`` through a call to
+    ``dpkg``.
+
 There are a few other environment variables used for building and testing
 only.
 

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -139,9 +139,11 @@ def live_build(root_dir, env):
     """
     # First, setup the build tools and workspace.
     # query the system to locate livecd-rootfs auto script installation path
-    proc = run('dpkg -L livecd-rootfs | grep "auto$"', shell=True,
-               env=os.environ)
-    auto_src = proc.stdout.strip()
+    auto_src = os.environ.get('UBUNTU_IMAGE_LIVECD_ROOTFS_AUTO_PATH')
+    if auto_src is None:
+        proc = run('dpkg -L livecd-rootfs | grep "auto$"', shell=True,
+                   env=os.environ)
+        auto_src = proc.stdout.strip()
     auto_dst = os.path.join(root_dir, 'auto')
     shutil.copytree(auto_src, auto_dst)
     # Create the commands and run config and build steps.

--- a/ubuntu_image/testing/helpers.py
+++ b/ubuntu_image/testing/helpers.py
@@ -125,15 +125,15 @@ class LiveBuildMocker:
         if ['lb', 'config'] == command[-2:]:
             self.call_args_list.append(command)
             return SimpleNamespace(returncode=1)
-        if ['lb', 'build'] == command[-2:]:
+        elif ['lb', 'build'] == command[-2:]:
             self.call_args_list.append(command)
             # Create dummy top-level filesystem layout.
             chroot_dir = os.path.join(self.root_dir, 'chroot')
             for dir_name in DIRS_UNDER_ROOTFS:
                 os.makedirs(os.path.join(chroot_dir, dir_name))
-
             return SimpleNamespace(returncode=1)
         elif command.startswith('dpkg -L'):
+            self.call_args_list.append(command)
             stdout = kws.pop('stdout', PIPE)
             stderr = kws.pop('stderr', PIPE)
             return subprocess_run(


### PR DESCRIPTION
(LP: #1734949)