### PR TITLE
Add allow-stderr to two of our basic tests as a workaround

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-image (1.4+18.10ubuntu1) UNRELEASED; urgency=medium
+
+  * Work-around Permission denied errors printing to stderr whenever parted is
+    imported, causing some of our basic autopkgtests failing.  (LP: #1775085)
+
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Tue, 12 Jun 2018 13:38:03 +0200
+
 ubuntu-image (1.3+18.04ubuntu2) bionic; urgency=medium
 
   * Ignore the E722 error on our bare-except statements as those are intended,

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -4,12 +4,12 @@ Depends: python3-ubuntu-image
 Test-Command: ubuntu-image --help
 Depends: ubuntu-image
 Features: test-name=help
-Restrictions: allow-stderr (LP: #1775085)
+Restrictions: allow-stderr # (LP: #1775085)
 
 Test-Command: ubuntu-image --version
 Depends: ubuntu-image
 Features: test-name=version
-Restrictions: allow-stderr (LP: #1775085)
+Restrictions: allow-stderr # (LP: #1775085)
 
 Test-Command: man ubuntu-image
 Depends: ubuntu-image, man-db

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -4,10 +4,12 @@ Depends: python3-ubuntu-image
 Test-Command: ubuntu-image --help
 Depends: ubuntu-image
 Features: test-name=help
+Restrictions: allow-stderr (LP: #1775085)
 
 Test-Command: ubuntu-image --version
 Depends: ubuntu-image
 Features: test-name=version
+Restrictions: allow-stderr (LP: #1775085)
 
 Test-Command: man ubuntu-image
 Depends: ubuntu-image, man-db


### PR DESCRIPTION
Work-around Permission denied errors printing to stderr whenever parted is imported, causing some of our basic autopkgtests failing.  (LP: #1775085)