### PR TITLE
Add --filesystem option for classic builds

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 ubuntu-image (1.5+18.10ubuntu1) UNRELEASED; urgency=medium
 
   * Fix bug with setting file owners in classic.  (LP: #1783577)
+  * Add --filesystem option for classic. This gives us the option to use an
+    existing unpacked root file system instead of calling live-build to create
+    it.  (LP: #1782795)
 
  -- Alfonso Sanchez-Beato (email Canonical) <alfonso.sanchez-beato@canonical.com>  Tue, 21 Aug 2018 14:45:48 +0200
 

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -247,7 +247,13 @@ def parseargs(argv=None):
     classic_cmd.add_argument(
         '-p', '--project',
         default=None, metavar='PROJECT',
-        help=_("""Project name to be specified to livecd-rootfs."""))
+        help=_("""Project name to be specified to livecd-rootfs. Mutually
+        exclusive with --filesystem."""))
+    classic_cmd.add_argument(
+        '-f', '--filesystem',
+        default=None, metavar='FILESYSTEM',
+        help=_("""Unpacked Ubuntu filesystem to be copied to the system
+        partition. Mutually exclusive with --project."""))
     classic_cmd.add_argument(
         '-s', '--suite',
         default=get_host_distro(), metavar='SUITE',
@@ -292,8 +298,10 @@ def parseargs(argv=None):
         if not args.resume:   # pragma: no branch
             if args.gadget_tree is None:
                 parser.error('gadget tree is required')
-            elif args.project is None:
-                parser.error('project is required')
+            elif args.project is None and args.filesystem is None:
+                parser.error('project or filesystem is required')
+            elif args.project and args.filesystem:
+                parser.error('project and filesystem are mutually exclusive')
     if args.resume and args.workdir is None:
         parser.error('--resume requires --workdir')
     # --until and --thru can take an int.

--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -66,7 +66,7 @@ class ClassicBuilder(AbstractImageBuilderState):
                     env['PROPOSED'] = self.args.with_proposed
                 if self.args.extra_ppas is not None:
                     env['EXTRA_PPAS'] = self.args.extra_ppas
-                # Only generate a single rootfs tree for classic image creation.
+                # Only generate a single rootfs tree for classic images.
                 env['IMAGEFORMAT'] = 'none'
                 # ensure ARCH is set
                 if self.args.arch is None:
@@ -76,7 +76,7 @@ class ClassicBuilder(AbstractImageBuilderState):
                 if self.args.debug:
                     _logger.exception('Full debug traceback follows')
                 self.exitcode = 1
-                # Stop the state machine right here by not appending a next step.
+                # Stop the state machine here by not appending a next step.
                 return
 
         super().prepare_image()

--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -101,12 +101,13 @@ class ClassicBuilder(AbstractImageBuilderState):
             shutil.rmtree(grub_folder, ignore_errors=True)
         # Replace pre-defined LABEL in /etc/fstab with the one
         # we're using 'LABEL=writable' in grub.cfg.
+        # TODO We need EFI partition in fstab too
         fstab_path = os.path.join(dst, 'etc', 'fstab')
         if os.path.exists(fstab_path):
             with open(fstab_path, 'r') as fstab:
                 new_content = re.sub(r'(LABEL=)\S+',
                                      r'\1{}'.format(DEFAULT_FS_LABEL),
-                                     fstab.read())
+                                     fstab.read(), count=1)
             # Insert LABEL entry if it's not found at fstab
             fs_label = 'LABEL={}'.format(DEFAULT_FS_LABEL)
             if fs_label not in new_content:

--- a/ubuntu_image/tests/test_classic_builder.py
+++ b/ubuntu_image/tests/test_classic_builder.py
@@ -201,6 +201,61 @@ class TestClassicBuilder(TestCase):
                 self.assertEqual(fp.read(), 'LABEL=writable   '
                                             '/    ext4   defaults    0 0')
 
+    def test_populate_rootfs_contents_from_filesystem(self):
+        with ExitStack() as resources:
+            workdir = resources.enter_context(TemporaryDirectory())
+            args = SimpleNamespace(
+                project=None,
+                suite='xenial',
+                arch='amd64',
+                image_format='img',
+                workdir=workdir,
+                output=None,
+                subproject=None,
+                subarch=None,
+                output_dir=None,
+                cloud_init=None,
+                with_proposed=None,
+                extra_ppas=None,
+                hooks_directory=[],
+                gadget_tree=self.gadget_tree,
+                filesystem=None,
+                )
+            state = resources.enter_context(XXXClassicBuilder(args))
+            # Now we have to craft enough of gadget definition to drive the
+            # method under test.
+            part = SimpleNamespace(
+                role=StructureRole.system_data,
+                filesystem_label='writable',
+                filesystem=FileSystemType.none,
+                )
+            volume = SimpleNamespace(
+                structures=[part],
+                bootloader=BootLoader.grub,
+                schema=VolumeSchema.gpt,
+                )
+            state.gadget = SimpleNamespace(
+                volumes=dict(volume1=volume),
+                )
+            prep_state(state, workdir)
+            # Fake some state expected by the method under test.
+            args.filesystem = resources.enter_context(TemporaryDirectory())
+            etc_path = os.path.join(args.filesystem, 'etc')
+            os.makedirs(etc_path)
+            with open(os.path.join(etc_path, 'fstab'), 'w') as fp:
+                fp.write('LABEL=cloudimg-rootfs   /    ext4   defaults    0 0')
+            state.rootfs = resources.enter_context(TemporaryDirectory())
+            # Jump right to the state method we're trying to test.
+            state._next.pop()
+            state._next.append(state.populate_rootfs_contents)
+            next(state)
+            # The seed metadata should exist.
+            # And the filesystem label should be modified to 'writable'
+            fstab_data = os.path.join(state.rootfs, 'etc', 'fstab')
+            with open(fstab_data, 'r', encoding='utf-8') as fp:
+                self.assertEqual(fp.read(), 'LABEL=writable   '
+                                            '/    ext4   defaults    0 0')
+
     def test_populate_rootfs_contents_empty_fstab_entry(self):
         with ExitStack() as resources:
             workdir = resources.enter_context(TemporaryDirectory())
@@ -878,6 +933,48 @@ class TestClassicBuilder(TestCase):
                 posargs, kwargs = mock.call_args_list[0]
                 self.assertIn(env, posargs[1])
                 self.assertEqual(posargs[1][env], 'test')
+
+    def test_filesystem_no_live_build_call(self):
+        with ExitStack() as resources:
+            argstoenv = {
+                'project': 'PROJECT',
+                'suite': 'SUITE',
+                'arch': 'ARCH',
+                'subproject': 'SUBPROJECT',
+                'subarch': 'SUBARCH',
+                'with_proposed': 'PROPOSED',
+                'extra_ppas': 'EXTRA_PPAS',
+                }
+            kwargs_skel = {
+                'workdir': '/tmp',
+                'output_dir': '/tmp',
+                'hooks_directory': '/tmp',
+                'output': None,
+                'cloud_init': None,
+                'gadget_tree': None,
+                'unpackdir': None,
+                'debug': None,
+                'project': None,
+                'suite': None,
+                'arch': None,
+                'subproject': None,
+                'subarch': None,
+                'with_proposed': None,
+                'extra_ppas': None,
+                'filesystem': '/tmp/fs',
+                }
+            for arg, env in argstoenv.items():
+                kwargs = dict(kwargs_skel)
+                kwargs[arg] = 'test'
+                args = SimpleNamespace(**kwargs)
+                # Jump right to the method under test.
+                state = resources.enter_context(XXXClassicBuilder(args))
+                state._next.pop()
+                state._next.append(state.prepare_image)
+                mock = resources.enter_context(patch(
+                    'ubuntu_image.classic_builder.live_build'))
+                next(state)
+                self.assertEqual(len(mock.call_args_list), 0)
 
     def test_generate_manifests_exclude(self):
         # This is not a full test of the manifest generation process as this

--- a/ubuntu_image/tests/test_classic_builder.py
+++ b/ubuntu_image/tests/test_classic_builder.py
@@ -78,6 +78,7 @@ class TestClassicBuilder(TestCase):
             extra_ppas=None,
             hooks_directory=[],
             gadget_tree=self.gadget_tree,
+            filesystem=None,
             )
         state = self._resources.enter_context(XXXClassicBuilder(args))
         gadget_dir = os.path.join(workdir, 'unpack', 'gadget')
@@ -119,6 +120,7 @@ class TestClassicBuilder(TestCase):
             extra_ppas='ppa:some/ppa',
             hooks_directory=[],
             gadget_tree=self.gadget_tree,
+            filesystem=None,
             )
         state = self._resources.enter_context(XXXClassicBuilder(args))
         # Mock out rootfs generation `live_build`
@@ -162,6 +164,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             # Now we have to craft enough of gadget definition to drive the
@@ -216,6 +219,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             # Now we have to craft enough of gadget definition to drive the
@@ -272,6 +276,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             # Now we have to craft enough of gadget definition to drive the
@@ -331,6 +336,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             # Now we have to craft enough of gadget definition to drive the
@@ -386,6 +392,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             # Now we have to craft enough of gadget definition to drive the
@@ -446,6 +453,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             state._next.pop()
@@ -535,6 +543,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             state._next.pop()
@@ -585,6 +594,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             state = resources.enter_context(XXXClassicBuilder(args))
             state._next.pop()
@@ -644,6 +654,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXClassicBuilder(args))
@@ -747,6 +758,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXClassicBuilder(args))
@@ -794,6 +806,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXClassicBuilder(args))
@@ -848,6 +861,7 @@ class TestClassicBuilder(TestCase):
                 'subarch': None,
                 'with_proposed': None,
                 'extra_ppas': None,
+                'filesystem': None,
                 }
             for arg, env in argstoenv.items():
                 kwargs = dict(kwargs_skel)
@@ -891,6 +905,7 @@ class TestClassicBuilder(TestCase):
                 extra_ppas=None,
                 hooks_directory=[],
                 gadget_tree=self.gadget_tree,
+                filesystem=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXClassicBuilder(args))

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -193,7 +193,7 @@ class TestParseArgs(TestCase):
         line = stderr.getvalue()
         self.assertIn('gadget tree is required', line)
 
-    def test_classic_project_required(self):
+    def test_classic_project_or_filesystem_required(self):
         stderr = StringIO()
         with patch('sys.stderr', stderr):
             self.assertRaises(SystemExit,
@@ -201,6 +201,16 @@ class TestParseArgs(TestCase):
                               ['classic', 'tree_url'])
         line = stderr.getvalue()
         self.assertIn('project or filesystem is required', line)
+
+    def test_classic_project_and_filesystem_exclusive(self):
+        stderr = StringIO()
+        with patch('sys.stderr', stderr):
+            self.assertRaises(SystemExit,
+                              parseargs,
+                              ['classic', 'tree_url', '--project',
+                               'ubuntu-cpc', '--filesystem', 'fsdir'])
+        line = stderr.getvalue()
+        self.assertIn('project and filesystem are mutually exclusive', line)
 
     def test_classic_resume_gadget_tree(self):
         stderr = StringIO()

--- a/ubuntu_image/tests/test_main.py
+++ b/ubuntu_image/tests/test_main.py
@@ -200,7 +200,7 @@ class TestParseArgs(TestCase):
                               parseargs,
                               ['classic', 'tree_url'])
         line = stderr.getvalue()
-        self.assertIn('project is required', line)
+        self.assertIn('project or filesystem is required', line)
 
     def test_classic_resume_gadget_tree(self):
         stderr = StringIO()


### PR DESCRIPTION
Add a filesystem option for classic builds, as an alternative to running live-build. The file system argument needs to be a folder with the system partition contents.

See https://bugs.launchpad.net/ubuntu-image/+bug/1782795 for more information.