### PR TITLE
parser: make "slot" in gadget connections optional

### DIFF
--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -173,7 +173,7 @@ GadgetYAML = Schema({
     },
     Optional('connections'): [Schema({
         Required('plug'): str,
-        Required('slot'): str,
+        Optional('slot'): str,
         })
     ],
     Optional('device-tree-origin', default='gadget'): str,

--- a/ubuntu_image/tests/test_parser.py
+++ b/ubuntu_image/tests/test_parser.py
@@ -57,6 +57,7 @@ volumes:
 connections:
   - plug: aaaa:bbbb
     slot: cccc:dddd
+  - plug: aaaa:bbbb
 volumes:
   first-image:
     bootloader: u-boot


### PR DESCRIPTION
The "slot" under connections in gadget.yaml is optional. This
PR updates the code to reflect that and adds a test.

See https://forum.snapcraft.io/t/the-gadget-snap/696 for the reference on this.