### PR TITLE
make "ubuntu-image snap" work even without dpkg installed

### DIFF
--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -11,7 +11,7 @@ from ubuntu_image import __version__
 from ubuntu_image.assertion_builder import ModelAssertionBuilder
 from ubuntu_image.classic_builder import ClassicBuilder
 from ubuntu_image.helpers import (
-    DoesNotFit, PrivilegeError, as_size, get_host_arch,
+    DoesNotFit, PrivilegeError, as_size,
     get_host_distro)
 from ubuntu_image.hooks import HookError
 from ubuntu_image.i18n import _
@@ -254,7 +254,7 @@ def parseargs(argv=None):
         help=_("""Distribution name to be specified to livecd-rootfs."""))
     classic_cmd.add_argument(
         '-a', '--arch',
-        default=get_host_arch(), metavar='CPU-ARCHITECTURE',
+        default=None, metavar='CPU-ARCHITECTURE',
         help=_("""CPU architecture to be specified to livecd-rootfs.
         default value is builder arch."""))
     classic_cmd.add_argument(

--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -9,7 +9,7 @@ from subprocess import CalledProcessError
 from tempfile import gettempdir
 from ubuntu_image.common_builder import AbstractImageBuilderState
 from ubuntu_image.helpers import (
-     check_root_privilege, live_build, run)
+     check_root_privilege, get_host_arch, live_build, run)
 from ubuntu_image.parser import (
     BootLoader, FileSystemType, StructureRole)
 
@@ -67,6 +67,9 @@ class ClassicBuilder(AbstractImageBuilderState):
                 env['EXTRA_PPAS'] = self.args.extra_ppas
             # Only genereate a single rootfs tree for classic image creation.
             env['IMAGEFORMAT'] = 'none'
+            # ensure ARCH is set
+            if self.args.arch is None:
+                env['ARCH'] = get_host_arch()
             live_build(self.unpackdir, env)
         except CalledProcessError:
             if self.args.debug:


### PR DESCRIPTION
Trivial drive-by PR that allows to run ubuntu-image in the
build ubuntu-core image mode even if no dpkg is installed.

Thanks for mborzecki for noticing that it won't run on arch.