### PR TITLE
No fakeroot for classic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
-ubuntu-image (1.4+18.10ubuntu1) UNRELEASED; urgency=medium
+ubuntu-image (1.4+18.10ubuntu2) UNRELEASED; urgency=medium
 
+  [ Łukasz 'sil2100' Zemczak ]
   * Add support for classic cross-compilation, add qemu-user-static as a
     dependency.  (LP: #1772061)
   * Work-around the API rate limit exceeded failures from github in the
@@ -11,7 +12,10 @@ ubuntu-image (1.4+18.10ubuntu1) UNRELEASED; urgency=medium
     Switch to using deb-packaged voluptuous.  (LP: #1782313)
   * Add the new connections: stanza to the gadget.yaml parser.  (LP: #1780217)
 
- -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Fri, 20 Jul 2018 16:43:51 +0200
+  [ Alfonso Sanchez-Beato (email Canonical) ]
+  * Fix bug with setting file owners in classic.  (LP: #1783577)
+
+ -- Alfonso Sanchez-Beato (email Canonical) <alfonso.sanchez-beato@canonical.com>  Tue, 21 Aug 2018 14:45:48 +0200
 
 ubuntu-image (1.3+18.04ubuntu2) bionic; urgency=medium
 

--- a/ubuntu_image/common_builder.py
+++ b/ubuntu_image/common_builder.py
@@ -286,8 +286,8 @@ class AbstractImageBuilderState(State):
                 # The root partition needs to be ext4, which may or may not be
                 # populated at creation time, depending on the version of
                 # e2fsprogs.
-                mkfs_ext4(part_img, self.rootfs, part.filesystem_label,
-                          preserve_ownership=True)
+                mkfs_ext4(part_img, self.rootfs, self.args.cmd,
+                          part.filesystem_label, preserve_ownership=True)
             elif part.filesystem is FileSystemType.none:
                 image = Image(part_img, part.size)
                 offset = 0
@@ -327,7 +327,8 @@ class AbstractImageBuilderState(State):
                 run('mcopy -s -i {} {} ::'.format(part_img, sourcefiles),
                     env=env)
             elif part.filesystem is FileSystemType.ext4:
-                mkfs_ext4(part_img, part_dir, part.filesystem_label)
+                mkfs_ext4(part_img, part_dir, self.args.cmd,
+                          part.filesystem_label)
             else:
                 raise AssertionError('Invalid part filesystem type: {}'.format(
                     part.filesystem))

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -213,9 +213,13 @@ def mkfs_ext4(img_file, contents_dir, image_type, label='writable',
     contents of an existing directory.  Unfortunately, we're targeting
     Ubuntu 16.04, which has e2fsprogs 1.42.X without the -d flag.  In
     that case, we have to sudo loop mount the ext4 file system and
-    populate it that way.  Which sucks because sudo.
-    NOTE Unfortunately we cannot use fakeroot for classic, as that changes the
-    ownership of the files - critical for /home/*
+    populate it that way.
+
+    Besides that, we need to use fakeroot for core so the files in the
+    partition are owned by root. For classic we want to keep the
+    ownership of the files created by live-build, so we do not use
+    fakeroot. But, we need to use sudo in that case so we can access
+    root read-only files in the contents folder.
     """
     if image_type == 'snap':
         sudo_cmd = 'fakeroot-sysv'

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -494,6 +494,7 @@ class TestModelAssertionBuilder(TestCase):
                 unpackdir=unpackdir,
                 workdir=workdir,
                 hooks_directory=[],
+                cmd='snap',
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -584,6 +585,7 @@ class TestModelAssertionBuilder(TestCase):
                 unpackdir=unpackdir,
                 workdir=workdir,
                 hooks_directory=[],
+                cmd='snap',
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -634,7 +636,7 @@ class TestModelAssertionBuilder(TestCase):
             self.assertEqual(
                 posargs,
                 # mkfs_ext4 positional arguments.
-                (part0_img, part0_path, 'hold the door'))
+                (part0_img, part0_path, 'snap', 'hold the door'))
 
     def test_populate_filesystems_bogus_type(self):
         # We do a bit-wise copy when the file system has no type.

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -461,7 +461,7 @@ class TestHelpers(TestCase):
                  'PROJECT=ubuntu-server', 'SUITE=xenial', 'ARCH=armhf',
                  'lb', 'config'])
 
-    def test_mkfs_ext4(self):
+    def aux_test_mkfs_ext4(self, cmd):
         with ExitStack() as resources:
             tmpdir = resources.enter_context(TemporaryDirectory())
             results_dir = os.path.join(tmpdir, 'results')
@@ -476,13 +476,19 @@ class TestHelpers(TestCase):
                 fp.write(b'56789')
             # And a fake image file.
             img_file = resources.enter_context(NamedTemporaryFile())
-            mkfs_ext4(img_file, contents_dir, 'snap')
+            mkfs_ext4(img_file, contents_dir, cmd)
             # Two files were put in the "mountpoint" directory, but because of
             # above, we have to check them in the results copy.
             with open(os.path.join(mock.results_dir, 'a.dat'), 'rb') as fp:
                 self.assertEqual(fp.read(), b'01234')
             with open(os.path.join(mock.results_dir, 'b.dat'), 'rb') as fp:
                 self.assertEqual(fp.read(), b'56789')
+
+    def test_mkfs_ext4_snap(self):
+        self.aux_test_mkfs_ext4('snap')
+
+    def test_mkfs_ext4_classic(self):
+        self.aux_test_mkfs_ext4('classic')
 
     def test_mkfs_ext4_no_contents(self):
         with ExitStack() as resources:

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -476,7 +476,7 @@ class TestHelpers(TestCase):
                 fp.write(b'56789')
             # And a fake image file.
             img_file = resources.enter_context(NamedTemporaryFile())
-            mkfs_ext4(img_file, contents_dir)
+            mkfs_ext4(img_file, contents_dir, 'snap')
             # Two files were put in the "mountpoint" directory, but because of
             # above, we have to check them in the results copy.
             with open(os.path.join(mock.results_dir, 'a.dat'), 'rb') as fp:
@@ -495,7 +495,7 @@ class TestHelpers(TestCase):
             contents_dir = resources.enter_context(TemporaryDirectory())
             # And a fake image file.
             img_file = resources.enter_context(NamedTemporaryFile())
-            mkfs_ext4(img_file, contents_dir)
+            mkfs_ext4(img_file, contents_dir, 'snap')
             # Because there were no contents, the `sudo cp` was never called,
             # the mock's shutil.copytree() was also never called, therefore
             # the results_dir was never created.
@@ -514,7 +514,7 @@ class TestHelpers(TestCase):
                 fp.write(b'01234')
             # And a fake image file.
             img_file = resources.enter_context(NamedTemporaryFile())
-            mkfs_ext4(img_file, contents_dir, preserve_ownership=True)
+            mkfs_ext4(img_file, contents_dir, 'snap', preserve_ownership=True)
             with open(os.path.join(mock.results_dir, 'a.dat'), 'rb') as fp:
                 self.assertEqual(fp.read(), b'01234')
             self.assertTrue(mock.preserves_ownership)


### PR DESCRIPTION
Do not use fakeroot for classic, as it messes up the ownership of files that do not belong to root, like /home/*.