### PR TITLE
Classic use tree

### DIFF
--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -93,11 +93,6 @@ class ClassicBuilder(AbstractImageBuilderState):
             for subdir in os.listdir(src):
                 shutil.move(os.path.join(src, subdir),
                             os.path.join(dst, subdir))
-        # Remove default grub bootloader settings as we ship bootloader bits
-        # (binary blobs and grub.cfg) to a generated rootfs locally.
-        grub_folder = os.path.join(dst, 'boot', 'grub')
-        if os.path.exists(grub_folder):
-            shutil.rmtree(grub_folder, ignore_errors=True)
         # Replace pre-defined LABEL in /etc/fstab with the one
         # we're using 'LABEL=writable' in grub.cfg.
         # TODO We need EFI partition in fstab too

--- a/ubuntu_image/tests/test_classic_builder.py
+++ b/ubuntu_image/tests/test_classic_builder.py
@@ -354,9 +354,6 @@ class TestClassicBuilder(TestCase):
             state.unpackdir = resources.enter_context(TemporaryDirectory())
             os.makedirs(os.path.join(state.unpackdir, 'chroot'))
             state.rootfs = resources.enter_context(TemporaryDirectory())
-            # While we're at it, make sure we also remove the old grub dir
-            grub_dirs = os.path.join(state.rootfs, 'boot', 'grub', 'test')
-            os.makedirs(grub_dirs, exist_ok=True)
             # Jump right to the state method we're trying to test.
             state._next.pop()
             state._next.append(state.populate_rootfs_contents)
@@ -478,8 +475,8 @@ class TestClassicBuilder(TestCase):
             state._next.pop()
             state._next.append(state.populate_rootfs_contents)
             next(state)
-            # There should be no default boot/grub path present.
-            self.assertFalse(os.path.exists(grub_dir))
+            # boot/grub should persist.
+            self.assertTrue(os.path.exists(grub_dir))
 
     def test_populate_bootfs_contents(self):
         # This test provides coverage for populate_bootfs_contents() when a


### PR DESCRIPTION
Do not remove /boot/grub, so `update-grub` does not fail in classic images