### PR TITLE
System-recovery partition to allow factory reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ diffcov.html
 demo/model.assertion
 *.model
 .tox
+.vscode

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-image (1.5+18.10ubuntu1) UNRELEASED; urgency=medium
+ubuntu-image (1.5+18.10ubuntu2) UNRELEASED; urgency=medium
 
   [ Alfonso Sanchez-Beato (email Canonical) ]
   * Fix bug with setting file owners in classic.  (LP: #1783577)
@@ -13,7 +13,11 @@ ubuntu-image (1.5+18.10ubuntu1) UNRELEASED; urgency=medium
   * Check for image/boot/<bootloader> for bootfs additional contents also for
     classic builds.  Ignore if it does not exist.  (LP: #1792561)
 
- -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Tue, 02 Oct 2018 17:07:58 +0200
+  [ James Jesudason ]
+  * Adds the creation of a system-recovery partition for factory reset.
+  * Creates backups on the system-recovery partition. 
+
+ -- James Jesudason <james.jesudason@canonical.com>  Wed, 14 Nov 2018 14:04:15 +0000
 
 ubuntu-image (1.4+18.10ubuntu4) cosmic; urgency=medium
 

--- a/ubuntu_image/assertion_builder.py
+++ b/ubuntu_image/assertion_builder.py
@@ -7,6 +7,8 @@ import logging
 from subprocess import CalledProcessError
 from ubuntu_image.common_builder import AbstractImageBuilderState
 from ubuntu_image.helpers import snap
+from ubuntu_image.image import Image
+from ubuntu_image.parser import StructureRole
 
 
 SYSTEMBOOT_BACKUP = 'system-boot.img'
@@ -101,11 +103,13 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
         for _, volume in self.gadget.volumes.items():
             for partnum, part in enumerate(volume.structures):
                 if part.role is StructureRole.system_boot:
-                    boot_target_dir = os.path.join(volume.basedir, 'part{}'.format(partnum))
+                    boot_target_dir = os.path.join(
+                        volume.basedir, 'part{}'.format(partnum))
                     boot_part = part
                     boot_schema = volume.schema
                 if part.role is StructureRole.system_recovery:
-                    target_dir = os.path.join(volume.basedir, 'part{}'.format(partnum))
+                    target_dir = os.path.join(
+                        volume.basedir, 'part{}'.format(partnum))
                     recovery = True
                 if recovery and target_dir and boot_target_dir:
                     break
@@ -120,7 +124,8 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
                 target_dir, boot_target_dir, boot_part, boot_schema)
         self._next.append(self.prepare_filesystems)
 
-    def _backup_system_boot(self, target_dir, boot_target_dir, part, boot_schema):
+    def _backup_system_boot(
+            self, target_dir, boot_target_dir, part, boot_schema):
         # Prepare the image file for system-boot
         imgfile = os.path.join(target_dir, SYSTEMBOOT_BACKUP)
         Image(imgfile, part.size, boot_schema)

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -88,6 +88,7 @@ class FileSystemType(Enum):
 class StructureRole(Enum):
     mbr = 'mbr'
     system_boot = 'system-boot'
+    system_recovery = 'system-recovery'
     system_data = 'system-data'
 
 
@@ -471,6 +472,11 @@ def parse(stream_or_string):
             if structure_role is None:
                 if filesystem_label == 'system-boot':
                     structure_role = StructureRole.system_boot
+                    warn('volumes:<volume name>:structure:<N>:filesystem_label'
+                         ' used for defining partition roles; use role '
+                         'instead.', DeprecationWarning)
+                elif filesystem_label == 'system-recovery':
+                    structure_role = StructureRole.system_recovery
                     warn('volumes:<volume name>:structure:<N>:filesystem_label'
                          ' used for defining partition roles; use role '
                          'instead.', DeprecationWarning)

--- a/ubuntu_image/tests/test_parser.py
+++ b/ubuntu_image/tests/test_parser.py
@@ -567,13 +567,19 @@ volumes:
     structure:
         - type: 00000000-0000-0000-0000-0000deafbead
           size: 400
+  fifth-image:
+    structure:
+        - type: 00000000-0000-0000-0000-0000deafbead
+          size: 500
+          role: system-recovery
 """)
-        self.assertEqual(len(gadget_spec.volumes), 4)
+        self.assertEqual(len(gadget_spec.volumes), 5)
         self.assertEqual({
             'first-image': StructureRole.mbr,
             'second-image': StructureRole.system_boot,
             'third-image': StructureRole.system_data,
             'fourth-image': None,
+            'fifth-image': StructureRole.system_recovery,
             },
             {key: gadget_spec.volumes[key].structures[0].role
              for key in gadget_spec.volumes}
@@ -846,6 +852,21 @@ volumes:
         partition = volume0.structures[0]
         self.assertEqual(partition.filesystem_label, 'system-boot')
         self.assertEqual(partition.role, StructureRole.system_boot)
+
+    def test_volume_special_label_system_recovery(self):
+        gadget_spec = parse("""\
+volumes:
+  first-image:
+    bootloader: u-boot
+    structure:
+        - type: 00000000-0000-0000-0000-0000feedface
+          size: 200
+          filesystem-label: system-recovery
+""")
+        volume0 = gadget_spec.volumes['first-image']
+        partition = volume0.structures[0]
+        self.assertEqual(partition.filesystem_label, 'system-recovery')
+        self.assertEqual(partition.role, StructureRole.system_recovery)
 
     def test_content_spec_a(self):
         gadget_spec = parse("""\


### PR DESCRIPTION
Adds the ability to create a system-recovery partition that can be used for a factory reset. The partition contains `/var/lib/snapd/seed`, which will be mounted read-only, and a copy of `/boot`. The gadget.yaml will expected a partition name or role as follows:

```
      - type: 83
        filesystem: ext4
        filesystem-label: system-recovery
        size: 358M
```

This is the first stage of changes for the factory-reset option.

