### PR TITLE
Ignore the 'grain' entry in the new pyparted partitiontable structure…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -8,8 +8,11 @@ ubuntu-image (1.7+19.04ubuntu1) UNRELEASED; urgency=medium
   * Add support for the new prepare-image --snap=<snap>=<channel|risk> syntax,
     bump the snapd dependency to 2.38.  (LP: #1815580)
   * Print a deprecation warning when using the old --extra-snaps syntax.
+  * Ignore the new 'grain' field in the pyparted partitiontable structure
+    during unit-tests, as otherwise it's causing test failures for disco+.
+    (LP: #1826224)
 
- -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Tue, 23 Apr 2019 12:56:41 +0200
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Wed, 24 Apr 2019 16:54:22 +0200
 
 ubuntu-image (1.6+19.04ubuntu1) disco; urgency=medium
 

--- a/ubuntu_image/tests/test_image.py
+++ b/ubuntu_image/tests/test_image.py
@@ -181,6 +181,11 @@ class TestImage(TestCase):
         partitions = disk_info['partitiontable']
         # The device id is unpredictable.
         partitions.pop('id')
+        # XXX: In later versions of pyparted the partitiontable structure
+        #  added a 'grain' entry that we're not really interested in.
+        #  Remove it so we can have the tests working for all series.
+        if 'grain' in partitions:
+            partitions.pop('grain')
         self.assertEqual(partitions, {
             'label': 'dos',
             'device': self.img,


### PR DESCRIPTION
… in our tests.

LP: #1826224