### PR TITLE
[DO NOT MERGE] add system-recovery role support for UC20

### DIFF
--- a/ubuntu_image/assertion_builder.py
+++ b/ubuntu_image/assertion_builder.py
@@ -37,6 +37,17 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
     def populate_rootfs_contents(self):
         src = os.path.join(self.unpackdir, 'image')
         dst = os.path.join(self.rootfs, 'system-data')
+
+        # FIXME: HACK HACK
+        # TODO we should probably check here for a 'recovery' directory
+        #      (produced by "snap prepare-image") and use that
+        from ubuntu_image.parser import StructureRole
+        for volume in self.gadget.volumes.values():
+            for part in volume.structures:
+                if part.role == StructureRole.system_recovery:
+                    dst = os.path.join(self.rootfs, "system", "current")
+                    break
+
         for subdir in os.listdir(src):
             # LP: #1632134 - copy everything under the image directory except
             # /boot which goes to the boot partition.

--- a/ubuntu_image/assertion_builder.py
+++ b/ubuntu_image/assertion_builder.py
@@ -45,7 +45,7 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
         for volume in self.gadget.volumes.values():
             for part in volume.structures:
                 if part.role == StructureRole.system_recovery:
-                    dst = os.path.join(self.rootfs, "system", "current")
+                    dst = self.rootfs
                     break
 
         for subdir in os.listdir(src):

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -89,6 +89,7 @@ class StructureRole(Enum):
     mbr = 'mbr'
     system_boot = 'system-boot'
     system_data = 'system-data'
+    system_recovery = 'system-recovery'
 
 
 class Enumify:
@@ -488,6 +489,10 @@ def parse(stream_or_string):
                     raise GadgetSpecificationError(
                         '`role: system-data` structure must have an implicit '
                         "label, or 'writable': {}".format(filesystem_label))
+            elif structure_role is StructureRole.system_recovery:
+                # recovery is good enough as a rootfs, the recovery will
+                # create the writable partition on demand
+                rootfs_seen = True
             # The content will be one of two formats, and no mixing is
             # allowed.  I.e. even though multiple content sections are allowed
             # in a single structure, they must all be of type A or type B.  If


### PR DESCRIPTION
This PR adds minimal (and hacky) support for the new "system-recovery"
role. When such a role in encountered ubuntu-image will:
- NOT create an implicit writable partition
- copy the content of the `snap prepare-image` "image" dir to
  /system/current/ (this is the recovery system base directory).

With these changes (and followups for `snap prepare-image`) we
can create a UC20 image with a recovery partition.

We should probably make this available in a branch of the ubuntu-image
git/snap so that we can use it to create UC20 dev images.