### PR TITLE
System seed boot dir

### DIFF
--- a/ubuntu_image/assertion_builder.py
+++ b/ubuntu_image/assertion_builder.py
@@ -48,10 +48,12 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
             dst = os.path.join(self.rootfs, 'system-data')
         for subdir in os.listdir(src):
             # LP: #1632134 - copy everything under the image directory except
-            # /boot which goes to the boot partition.
-            if subdir != 'boot':
-                shutil.move(os.path.join(src, subdir),
-                            os.path.join(dst, subdir))
+            # /boot which goes to the boot partition. Unless this is a uc20
+            # system which has everything under "system-seed".
+            if not self.gadget.seeded and subdir == 'boot':
+                continue
+            shutil.move(os.path.join(src, subdir),
+                        os.path.join(dst, subdir))
         etc_cloud = os.path.join(dst, 'etc', 'cloud')
         if os.path.isdir(etc_cloud) and not os.listdir(etc_cloud):
             # The snap --prepare-image command creates /etc/cloud even if

--- a/ubuntu_image/assertion_builder.py
+++ b/ubuntu_image/assertion_builder.py
@@ -73,7 +73,7 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
             userdata_file = os.path.join(cloud_dir, 'user-data')
             shutil.copy(self.cloud_init, userdata_file)
         # This is just a mount point.
-        os.makedirs(os.path.join(dst, 'boot'))
+        os.makedirs(os.path.join(dst, 'boot'), exist_ok=True)
         super().populate_rootfs_contents()
 
     def _write_manifest(self, snaps_dir, filename):


### PR DESCRIPTION
The current code assumes that /boot can be skipped when the
rootfs is populated. This was a fine assumption for uc16/uc18
but in the uc20 world the only "rootfs" we have is the ubuntu-seed
partition. Here we want to copy the /boot directory with the
grub config so that we have a valid recovery grub installed.