### PR TITLE
System seed boot content

### DIFF
--- a/ubuntu_image/common_builder.py
+++ b/ubuntu_image/common_builder.py
@@ -192,8 +192,16 @@ class AbstractImageBuilderState(State):
 
     def _populate_one_bootfs(self, name, volume):
         for partnum, part in enumerate(volume.structures):
-            target_dir = os.path.join(volume.basedir, 'part{}'.format(partnum))
-            if part.role is StructureRole.system_boot:
+            if part.role is StructureRole.system_seed:
+                # For seeded systems, the system-seed partition (which reuses
+                # the rootfs paths) is also the boot partition - so we need
+                # to redirect all the boot copies there as well.
+                target_dir = self.rootfs
+            else:
+                target_dir = os.path.join(
+                    volume.basedir, 'part{}'.format(partnum))
+            if part.role in (StructureRole.system_boot,
+                             StructureRole.system_seed):
                 volume.bootfs = target_dir
                 if volume.bootloader is BootLoader.uboot:
                     boot = os.path.join(


### PR DESCRIPTION
Perform boot file copies for system-seed as well. Make sure content copies go to the right directory.

So I'm still not sure if the copies from the rootfs to the EFI dirs etc. are needed, but certainly it should not be an issue to have that. Previously I assumed that the generated system-seed rootfs would simply have everything present already. Anyway, hope this fixes it, only tested it on unit tests for now.