### PR TITLE
ubuntu_image: update schema validator to allow gadget update specific keys & little cleanups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'attrs',
         'pyyaml',
         'voluptuous',
+        'pyparted',
         ],
     include_package_data=True,
     scripts=['ubuntu-image'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37}-{nocov,cov,diffcov},qa,docs
+envlist = {py35,py36,py37,py38}-{nocov,cov,diffcov},qa,docs
 #recreate = True
 skip_missing_interpreters = True
 

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -11,7 +11,7 @@ from pkg_resources import parse_version
 from ubuntu_image.helpers import GiB, MiB, as_size, get_default_sector_size
 from uuid import UUID
 from voluptuous import (
-    Any, Coerce, Invalid, Match, Optional, Required, Schema,
+    All, Any, Coerce, Invalid, Match, Optional, Range, Required, Schema,
     __version__ as voluptuous_version)
 from warnings import warn
 from yaml import load
@@ -229,7 +229,12 @@ GadgetYAML = Schema({
                         Optional('size'): Coerce(as_size),
                         })
                     ],
-                )
+                ),
+                Optional('update'): Schema({
+                    Optional('edition'): All(
+                        Coerce(int), Range(min=0, min_included=True)),
+                    Optional('preserve'): [str],
+                }),
             })]
         })
     }

--- a/ubuntu_image/tests/test_parser.py
+++ b/ubuntu_image/tests/test_parser.py
@@ -2107,6 +2107,43 @@ volumes:
         self.assertEqual(partition2.filesystem, FileSystemType.ext4)
         self.assertEqual(partition2.filesystem_label, 'writable')
 
+    def test_invalid_volume_name(self):
+        for name in ["-invalid", "in valid", "in+valid"]:
+            with ExitStack() as resources:
+                cm = resources.enter_context(
+                    self.assertRaises(GadgetSpecificationError))
+                parse("""\
+volumes:
+  {}:
+    bootloader: u-boot
+    structure:
+        - role: mbr
+          type: 00000000-0000-0000-0000-0000deadbeef
+          size: 446
+          offset: 10
+""".format(name))
+            self.assertEqual(str(cm.exception),
+                             'Invalid gadget.yaml @ volumes:{}'.format(name))
+
+    def test_duplicate_structure_name(self):
+        with ExitStack() as resources:
+            cm = resources.enter_context(
+                self.assertRaises(GadgetSpecificationError))
+            parse("""\
+volumes:
+  vol:
+    bootloader: u-boot
+    structure:
+        - type: 00000000-0000-0000-0000-dd00deadbeef
+          name: not-unique
+          size: 10M
+        - type: 00000000-0000-0000-0000-dd00deadbeee
+          name: not-unique
+          size: 10M
+""")
+        self.assertEqual(str(cm.exception),
+                         'Structure name "not-unique" is not unique')
+
 
 class TestPartOrder(TestCase):
     # LP: #1631423
@@ -2228,40 +2265,3 @@ volumes:
         partition4 = volume0.structures[4]
         self.assertEqual(partition4.role, StructureRole.system_data)
         self.assertEqual(partition4.offset, MiB(1200))
-
-    def test_invalid_volume_name(self):
-        for name in ["-invalid", "in valid", "in+valid"]:
-            with ExitStack() as resources:
-                cm = resources.enter_context(
-                    self.assertRaises(GadgetSpecificationError))
-                parse("""\
-volumes:
-  {}:
-    bootloader: u-boot
-    structure:
-        - role: mbr
-          type: 00000000-0000-0000-0000-0000deadbeef
-          size: 446
-          offset: 10
-""".format(name))
-            self.assertEqual(str(cm.exception),
-                             'Invalid gadget.yaml @ volumes:{}'.format(name))
-
-    def test_duplicate_structure_name(self):
-        with ExitStack() as resources:
-            cm = resources.enter_context(
-                self.assertRaises(GadgetSpecificationError))
-            parse("""\
-volumes:
-  vol:
-    bootloader: u-boot
-    structure:
-        - type: 00000000-0000-0000-0000-dd00deadbeef
-          name: not-unique
-          size: 10M
-        - type: 00000000-0000-0000-0000-dd00deadbeee
-          name: not-unique
-          size: 10M
-""")
-        self.assertEqual(str(cm.exception),
-                         'Structure name "not-unique" is not unique')


### PR DESCRIPTION
As part of gadget updates support in snapd, the structure supports extra keys,
like so:

```
volume:
  foo:
    ...
    structure:
      - name: structure for update
        update:
          edition: 123   # structure content edition
          preserve:      # list of preserved files
            - foo.txt
```

Update schema validator to allow new entries. Make sure that the entries are of
correct type/value.

Include some additional cleanups.

cc @sil2100 