### PR TITLE
No longer remove /boot/grub from the rootfs for classic image builds

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,12 @@ ubuntu-image (1.8+20.04ubuntu3) UNRELEASED; urgency=medium
   * ubuntu_image: update schema validator to allow gadget update specific
     keys & little cleanups.  (LP: #1856903)
 
- -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Thu, 19 Dec 2019 19:22:57 +0100
+  [ Łukasz 'sil2100' Zemczak ]
+  * Design change: no longer remove /boot/grub from the rootfs for classic
+    image builds.  This allows developers to have more freedom on deciding how
+    boot configuration should be handled.  (LP: #1817050)
+
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Tue, 14 Jan 2020 14:55:37 +0100
 
 ubuntu-image (1.8+20.04ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,15 +3,13 @@ ubuntu-image (1.8+20.04ubuntu3) UNRELEASED; urgency=medium
   [ Łukasz 'sil2100' Zemczak ]
   * Add support for populating a .disk/info file on the target image rootfs.
     (LP: #1856684)
+  * Design change: no longer remove /boot/grub from the rootfs for classic
+    image builds.  This allows developers to have more freedom on deciding how
+    boot configuration should be handled.  (LP: #1817050)
 
   [ Maciej Borzecki ]
   * ubuntu_image: update schema validator to allow gadget update specific
     keys & little cleanups.  (LP: #1856903)
-
-  [ Łukasz 'sil2100' Zemczak ]
-  * Design change: no longer remove /boot/grub from the rootfs for classic
-    image builds.  This allows developers to have more freedom on deciding how
-    boot configuration should be handled.  (LP: #1817050)
 
  -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Tue, 14 Jan 2020 14:55:37 +0100
 

--- a/ubuntu_image/classic_builder.py
+++ b/ubuntu_image/classic_builder.py
@@ -91,16 +91,6 @@ class ClassicBuilder(AbstractImageBuilderState):
             for subdir in os.listdir(src):
                 shutil.move(os.path.join(src, subdir),
                             os.path.join(dst, subdir))
-        # Remove default grub bootloader settings as we ship bootloader bits
-        # (binary blobs and grub.cfg) to a generated rootfs locally.
-        grub_folder = os.path.join(dst, 'boot', 'grub')
-        if os.path.exists(grub_folder):
-            for file_name in os.listdir(grub_folder):
-                file_path = os.path.join(grub_folder, file_name)
-                if os.path.isdir(file_path):
-                    shutil.rmtree(file_path, ignore_errors=True)
-                else:
-                    os.unlink(file_path)
         # Replace pre-defined LABEL in /etc/fstab with the one
         # we're using 'LABEL=writable' in grub.cfg.
         # TODO We need EFI partition in fstab too

--- a/ubuntu_image/tests/test_classic_builder.py
+++ b/ubuntu_image/tests/test_classic_builder.py
@@ -431,7 +431,10 @@ class TestClassicBuilder(TestCase):
             with open(meta_data, 'r', encoding='utf-8') as fp:
                 self.assertEqual(fp.read(), 'instance-id: nocloud-static\n')
 
-    def test_populate_rootfs_contents_grub_boot_remove(self):
+    def test_populate_rootfs_contents_grub_boot_preserved(self):
+        # We changed our design, so this test is here to make sure the new
+        # design of preserving /boot/grub works.  Previously we removed all
+        # contents of that directory, leaving it empty.
         with ExitStack() as resources:
             workdir = resources.enter_context(TemporaryDirectory())
             args = SimpleNamespace(
@@ -484,10 +487,10 @@ class TestClassicBuilder(TestCase):
             state._next.pop()
             state._next.append(state.populate_rootfs_contents)
             next(state)
-            # /boot/grub should persist, but not the files inside
+            # /boot/grub should persist
             self.assertTrue(os.path.exists(grub_dir))
-            self.assertFalse(os.path.exists(grub_inside_dir))
-            self.assertFalse(os.path.exists(grub_file))
+            self.assertTrue(os.path.exists(grub_inside_dir))
+            self.assertTrue(os.path.exists(grub_file))
 
     def test_populate_bootfs_contents(self):
         # This test provides coverage for populate_bootfs_contents() when a


### PR DESCRIPTION
So actually after some thinking and discussion with Steve (per discussions with Alfonso), we came to the conclusion that it's best if we just stop wiping out the grub boot configuration from the rootfs. There were some reasons for that in the past, but actually preserving it makes the whole experience more intuitive.

LP: #1817050