### PR TITLE
Better approach to UC20 unsupported arguments

### DIFF
--- a/ubuntu_image/common_builder.py
+++ b/ubuntu_image/common_builder.py
@@ -22,10 +22,6 @@ SPACE = ' '
 _logger = logging.getLogger('ubuntu-image')
 
 
-class UnsupportedFeatureError(Exception):
-    """A (temporary) exception raised on an unsupported feature."""
-
-
 class AbstractImageBuilderState(State):
     """Abstract class for image building.
 
@@ -140,17 +136,6 @@ class AbstractImageBuilderState(State):
         shutil.copy(self.yaml_file_path, self.workdir)
         with open(self.yaml_file_path, 'r', encoding='utf-8') as fp:
             self.gadget = parse_yaml(fp)
-        # XXX: This is temporary
-        # Let's knowingly error out for now when someone tries to pass
-        # --cloud-init, --disable-console-conf or --disk-info when building
-        # a seeded UC20 image, as it is not supported by snapd yet.
-        if self.gadget.seeded:
-            # We should make sure to remove this once we get proper support
-            # for these in UC20.
-            if self.cloud_init:
-                raise UnsupportedFeatureError('--cloud-init')
-            if self.disable_console_conf:  # pragma: no branch
-                raise UnsupportedFeatureError('--disable-console-conf')
         # Make a working subdirectory for every volume we're going to create.
         # We'll put the volume contents inside these directories, and then use
         # the directories to create the disk images, one per volume.

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -12,7 +12,6 @@ from struct import unpack
 from subprocess import CalledProcessError
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from types import SimpleNamespace
-from ubuntu_image.common_builder import UnsupportedFeatureError
 from ubuntu_image.helpers import DoesNotFit, MiB, run
 from ubuntu_image.parser import (
     BootLoader, FileSystemType, StructureRole, VolumeSchema)
@@ -3291,46 +3290,6 @@ class TestModelAssertionBuilder(TestCase):
                 'unpack/gadget/meta/gadget.yaml',
                 'unpack/gadget/shim.efi.signed',
                 ])
-
-    def test_temporary_error_on_uc20_unsupported_features(self):
-        test_cases = {
-            'disable_console_conf': {
-                'value': True, 'exception': '--disable-console-conf'
-            },
-            'cloud_init': {
-                'value': 'some/path', 'exception': '--cloud-init'
-            },
-        }
-        for arg, test in test_cases.items():
-            with ExitStack() as resources:
-                workdir = resources.enter_context(TemporaryDirectory())
-                args = SimpleNamespace(
-                    output=None,
-                    output_dir=None,
-                    model_assertion=self.model_assertion,
-                    workdir=workdir,
-                    hooks_directory=[],
-                    cloud_init=None,
-                    disk_info=None,
-                    disable_console_conf=False,
-                    debug=False,
-                    )
-                # Apply the selected test case
-                setattr(args, arg, test['value'])
-                state = resources.enter_context(XXXModelAssertionBuilder(args))
-                state.unpackdir = resources.enter_context(TemporaryDirectory())
-                state._next.pop()
-                state._next.append(state.load_gadget_yaml)
-                mock = resources.enter_context(
-                    patch('ubuntu_image.common_builder.parse_yaml'))
-                # We only care about 'seeded' - if any other fields are being
-                # accessed before erroring out, that is also an error and
-                # means that we're not doing what we're supposed to.
-                mock.return_value = SimpleNamespace(seeded=True)
-                with self.assertRaises(UnsupportedFeatureError) as cm:
-                    next(state)
-                # Check if the right exception has been thrown
-                self.assertEqual(str(cm.exception), test['exception'])
 
     def test_temporary_skip_hooks_on_uc20(self):
         with ExitStack() as resources:


### PR DESCRIPTION
The previous one was failing too late, since prepare-image had to first do its thing (started noticing how annoying it is once snap downloads got slower). This is better. Not the best way, as I wanted to avoid guessing the model so early, but at least does its job.

Marking 'trivial' as we will re-use the changelog entry from before.