### PR TITLE
Demote snapd to recommends, to make ubuntu-image installable on riscv64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,16 @@
 ubuntu-image (1.9+20.04ubuntu2) UNRELEASED; urgency=medium
 
+  [ Łukasz 'sil2100' Zemczak ]
   * Add a quick option to disable console-conf.  (LP: #1866002)
   * Disable some of the unsupported features for UC20 models.  (LP: #1875431)
     - --disable-console-conf
     - --cloud-init
     - Running the post-populate-rootfs hook.
   * Do not create an empty /boot on the system-seed partition.
+
+  [ Dimitri John Ledkov ]
+  * Demote snapd to recommends, to make ubuntu-image installable on
+    riscv64 architecture. LP: #1876338
 
  -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Mon, 27 Apr 2020 18:02:07 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -51,9 +51,9 @@ Depends: ca-certificates,
          python3-setuptools,
          python3-voluptuous,
          python3-yaml,
-         snapd (>= 2.38~),
          ${misc:Depends},
          ${python3:Depends},
+Recommends: snapd (>= 2.38~)
 Suggests: qemu-user-static,
 Description: toolkit for building Ubuntu images
  .


### PR DESCRIPTION
Demote snapd to recommends, to make ubuntu-image installable on riscv64