### PR TITLE
Pacify flake8 in groovy.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -15,6 +15,9 @@ ubuntu-image (1.9+20.04ubuntu4) UNRELEASED; urgency=medium
   * Do not overwrite the files that snap prepare-image has created.
     (LP: #1884247)
 
+  [ Dimitri John Ledkov ]
+  * Pacify flake8 in groovy.
+
  -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Fri, 26 Jun 2020 10:27:42 +0200
 
 ubuntu-image (1.9+20.04ubuntu3) groovy; urgency=medium

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -196,7 +196,7 @@ GadgetYAML = Schema({
         Match('^[a-zA-Z0-9][-a-zA-Z0-9]*$'): Schema({
             Optional('schema', default='gpt' if has_new_voluptuous()
                      else VolumeSchema.gpt):
-                Enumify(VolumeSchema),
+            Enumify(VolumeSchema),
             Optional('bootloader'): Enumify(
                 BootLoader, preprocessor=methodcaller('replace', '-', '')),
             Optional('id'): Coerce(Id),
@@ -213,7 +213,7 @@ GadgetYAML = Schema({
                 Optional('id'): Coerce(UUID),
                 Optional('filesystem', default='none' if has_new_voluptuous()
                          else FileSystemType.none):
-                    Enumify(FileSystemType),
+                Enumify(FileSystemType),
                 Optional('filesystem-label'): str,
                 Optional('content'): Any(
                     [Schema({
@@ -227,8 +227,7 @@ GadgetYAML = Schema({
                         Optional('offset-write'): Any(
                             Coerce(Size32bit), RelativeOffset),
                         Optional('size'): Coerce(as_size),
-                        })
-                    ],
+                        })],
                 ),
                 Optional('update'): Schema({
                     Optional('edition'): All(


### PR DESCRIPTION
Currently ubuntu-image is failing flake8 test in groovy, blocking livecd-rootfs migration.

Time to upload ubuntu-image into groovy?