### PR TITLE
Fix UC20 image size calculation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,9 @@ ubuntu-image (1.9+20.04ubuntu4) UNRELEASED; urgency=medium
     - --cloud-init
     - Running the post-populate-rootfs hook.
   * Do not create an empty /boot on the system-seed partition.
+  * Switch the approach of building UC20 images to ensure that all partitions
+    defined in the gadget are considered in image size calculations.
+    (LP: #1859973)
 
   [ Michael Hudson-Doyle ]
   * Add dependency on fdisk now that it is no longer Essential.  (LP: #1877485)
@@ -18,7 +21,7 @@ ubuntu-image (1.9+20.04ubuntu4) UNRELEASED; urgency=medium
   [ Dimitri John Ledkov ]
   * Pacify flake8 in groovy.
 
- -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Fri, 26 Jun 2020 10:27:42 +0200
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Thu, 03 Sep 2020 10:20:28 +0200
 
 ubuntu-image (1.9+20.04ubuntu3) groovy; urgency=medium
 

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -500,7 +500,7 @@ def parse(stream_or_string):
                 # For images to work the system-data (rootfs) partition needs
                 # to have the 'writable' filesystem label set.
                 # For UC20 this requirement no longer stands.
-                if (filesystem_label not in (None, 'writable') and 
+                if (filesystem_label not in (None, 'writable') and
                         not is_seeded):
                     raise GadgetSpecificationError(
                         '`role: system-data` structure must have an implicit '

--- a/ubuntu_image/parser.py
+++ b/ubuntu_image/parser.py
@@ -499,7 +499,9 @@ def parse(stream_or_string):
                 rootfs_seen = True
                 # For images to work the system-data (rootfs) partition needs
                 # to have the 'writable' filesystem label set.
-                if filesystem_label not in (None, 'writable'):
+                # For UC20 this requirement no longer stands.
+                if (filesystem_label not in (None, 'writable') and 
+                        not is_seeded):
                     raise GadgetSpecificationError(
                         '`role: system-data` structure must have an implicit '
                         "label, or 'writable': {}".format(filesystem_label))
@@ -549,10 +551,6 @@ def parse(stream_or_string):
                 structure_type, structure_id, structure_role,
                 filesystem, filesystem_label,
                 content_specs))
-            # If we found a system-seed partition, stop looking at other
-            # parts.
-            if is_seeded:
-                break
         # Sort structures by their offset.
         volume_specs[image_name] = VolumeSpec(
             schema, bootloader, image_id, structures)

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -2200,7 +2200,7 @@ class TestModelAssertionBuilder(TestCase):
                 offset_write=None,
                 )
             volume = SimpleNamespace(
-                structures=[part0, part1],
+                structures=[part0, part1, part2],
                 schema=VolumeSchema.gpt,
                 )
             state.gadget = SimpleNamespace(


### PR DESCRIPTION
Let's switch to the previous approach of UC20 image building. We no longer 'discard' all the partitions after the seed partition but instead simply skip acting on those that are meant to be managed by snapd. Thinking about it a bit more, this approach seems conceptually better as in the past our partition definitions could not be out of order (which is valid gadget.yaml with the use of offsets etc.) in certain cases (like if some partition was defined in the structure after the seed partition, but having earlier offset) or when for some weird reasons we'd want to have some funky raw partition at the end of the image - though the last one I'm not really sure if it's supported.

Anyway, if we need to actually put some hard restrictions that 'the seed partition needs to be the last partition on the image', we might need to follow up with another PR. But I don't think we actually need that.

LP: #1859973

