### PR TITLE
Don't use capture_output as that's py3.7+ only

### DIFF
--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -10,7 +10,7 @@ import contextlib
 from contextlib import ExitStack, contextmanager
 from distutils.spawn import find_executable
 from parted import Device
-from subprocess import PIPE, run as subprocess_run
+from subprocess import DEVNULL, PIPE, run as subprocess_run
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from ubuntu_image.state import ExpectedError
 
@@ -218,7 +218,7 @@ def unsparse_swapfile_ext4(img_file):
         if os.path.exists(swapfile_path):
             cmd = ('dd if={swapfile} of={swapfile} conv=notrunc '
                    'bs=1M'.format(swapfile=swapfile_path))
-            run(cmd, stdout=None, stderr=None, capture_output=False)
+            run(cmd, stdout=DEVNULL, stderr=DEVNULL)
 
 
 def mkfs_ext4(img_file, contents_dir, image_type, label='writable',

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from contextlib import ExitStack
 from pkg_resources import resource_filename
 from shutil import copytree
-from subprocess import run as subprocess_run
+from subprocess import DEVNULL, run as subprocess_run
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from types import SimpleNamespace
 from ubuntu_image.helpers import (
@@ -89,7 +89,7 @@ class MountMocker:
             if self.contents_dir:
                 subprocess_run('cp {}/* {}'.format(
                     self.contents_dir, self.mountpoint), shell=True,
-                    capture_output=False)
+                    stdout=DEVNULL, stderr=DEVNULL)
         elif command.startswith('sudo umount'):
             # Just ignore the umount command since we never mounted anything,
             # and it's a temporary directory anyway.
@@ -109,7 +109,7 @@ class MountMocker:
                 self.preserves_ownership = True
         elif command.startswith('dd'):
             # dd is a safe command so we should just run it.
-            subprocess_run(command, shell=True, capture_output=False)
+            subprocess_run(command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
             self.dd_called = True
 
 
@@ -589,7 +589,7 @@ class TestHelpers(TestCase):
             # Empty swapfile.
             swapfile = os.path.join(results_dir, 'swapfile')
             run('dd if=/dev/zero of={} bs=10M count=1'.format(swapfile),
-                stdout=None, stderr=None, capture_output=False)
+                stdout=DEVNULL, stderr=DEVNULL)
             # Image file.
             img_file = resources.enter_context(NamedTemporaryFile())
             mock = MountMocker(results_dir, results_dir)


### PR DESCRIPTION
Trivial change to make the latest bits pass on xenial (with older python3 versions) as well.