### PR TITLE
Update the link to the gadget.yaml specification in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,9 @@ Project details
 * Manual page: man ubuntu-image
   (https://github.com/CanonicalLtd/ubuntu-image/blob/master/ubuntu-image.rst)
 
-The ``gadget.yaml`` specification has moved to `the snapcore repository`_.
+The ``gadget.yaml`` specification has moved to `the snapcraft forum`_.
 
-.. _`the snapcore repository`: https://github.com/snapcore/snapd/wiki/Gadget-snap
+.. _`the snapcraft forum`: https://forum.snapcraft.io/t/the-gadget-snap/696
 
 
 Developing

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Project details
 
 The ``gadget.yaml`` specification has moved to `the snapcraft forum`_.
 
-.. _`the snapcraft forum`: https://forum.snapcraft.io/t/the-gadget-snap/696
+.. _`the snapcraft forum`: https://forum.snapcraft.io/t/the-gadget-snap
 
 
 Developing


### PR DESCRIPTION
I came across an outdated link to gagdet.yaml specification in the README.
It appears to have moved to the Snapcraft forum, so I went ahead and updated the link appropriately.