### PR TITLE
Add --factory-image command option

### DIFF
--- a/ubuntu-image.rst
+++ b/ubuntu-image.rst
@@ -98,6 +98,8 @@ model_assertion
 --disable-console-conf
     Disable console-conf on the resulting image.
 
+--factory-image
+    Hint that the image is meant to boot in a device factory.
 
 Classic command options
 -----------------------

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -256,6 +256,11 @@ def parseargs(argv=None):
         '--disable-console-conf',
         default=False, action='store_true',
         help=_("""Disable console-conf on the resulting image."""))
+    snap_cmd.add_argument(
+        '--factory-image',
+        default=False, action='store_true',
+        help=_("""Hint that the image is meant to boot in a device
+        factory."""))
     # Classic-based image options.
     classic_cmd.add_argument(
         'gadget_tree', nargs='?',
@@ -325,6 +330,8 @@ def parseargs(argv=None):
                 parser.error('project and filesystem are mutually exclusive')
         # And classic doesn't use console-conf
         args.disable_console_conf = False
+        # nor has a concept of factory images
+        args.factory_image = False
     if args.resume and args.workdir is None:
         parser.error('--resume requires --workdir')
     # --until and --thru can take an int.

--- a/ubuntu_image/assertion_builder.py
+++ b/ubuntu_image/assertion_builder.py
@@ -25,7 +25,8 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
             snap(self.args.model_assertion, self.unpackdir, self.workdir,
                  channel=self.args.channel, extra_snaps=extra_snaps,
                  cloud_init=self.cloud_init,
-                 disable_console_conf=self.disable_console_conf)
+                 disable_console_conf=self.disable_console_conf,
+                 factory_image=self.factory_image)
         except CalledProcessError:
             if self.args.debug:
                 _logger.exception('Full debug traceback follows')

--- a/ubuntu_image/common_builder.py
+++ b/ubuntu_image/common_builder.py
@@ -61,6 +61,7 @@ class AbstractImageBuilderState(State):
         self.cloud_init = args.cloud_init
         self.disk_info = args.disk_info
         self.disable_console_conf = args.disable_console_conf
+        self.factory_image = args.factory_image
         self.exitcode = 0
         self.done = False
         # Generic hook handling manager.
@@ -75,6 +76,7 @@ class AbstractImageBuilderState(State):
             cloud_init=self.cloud_init,
             disk_info=self.disk_info,
             disable_console_conf=self.disable_console_conf,
+            factory_image=self.factory_image,
             done=self.done,
             exitcode=self.exitcode,
             gadget=self.gadget,
@@ -96,6 +98,7 @@ class AbstractImageBuilderState(State):
         self.cloud_init = state['cloud_init']
         self.disk_info = state['disk_info']
         self.disable_console_conf = state['disable_console_conf']
+        self.factory_image = state['factory_image']
         self.done = state['done']
         self.exitcode = state['exitcode']
         self.gadget = state['gadget']

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -126,7 +126,7 @@ def run(command, *, check=True, **args):
 
 
 def snap(model_assertion, root_dir, workdir, channel=None, extra_snaps=None,
-         cloud_init=None, disable_console_conf=None):
+         cloud_init=None, disable_console_conf=None, factory_image=None):
     snap_cmd = os.environ.get('UBUNTU_IMAGE_SNAP_CMD', 'snap')
     # Create a list of the command arguments to run.  We do it this way rather
     # than just .format() into a template string in order to have a more
@@ -146,6 +146,9 @@ def snap(model_assertion, root_dir, workdir, channel=None, extra_snaps=None,
     if disable_console_conf:
         # For now by default console-conf is always enabled.
         customize['console-conf'] = 'disabled'
+    if factory_image:
+        # The factory image hint for UC20 is set as a boot flag
+        customize['boot-flags'] = ['factory']
     if customize:
         customize_path = os.path.join(workdir, 'customization')
         with open(customize_path, 'w') as fp:

--- a/ubuntu_image/testing/nose.py
+++ b/ubuntu_image/testing/nose.py
@@ -78,7 +78,8 @@ class MockerBase:
 class SecondAndOnwardMock(MockerBase):
     def snap_mock(self, model_assertion, root_dir, workdir,
                   channel=None, extra_snaps=None,
-                  cloud_init=None, disable_console_conf=None):
+                  cloud_init=None, disable_console_conf=None,
+                  factory_image=None):
         run_tmp = os.path.join(
             self._tmpdir,
             self._checksum(model_assertion, channel))
@@ -88,7 +89,8 @@ class SecondAndOnwardMock(MockerBase):
             with patch('ubuntu_image.helpers.run', mock_run):
                 real_snap(model_assertion, tmp_root, self._tmpdir, channel,
                           cloud_init=cloud_init,
-                          disable_console_conf=disable_console_conf)
+                          disable_console_conf=disable_console_conf,
+                          factory_image=factory_image)
         # copytree() requires that the destination directories do not exist.
         # Since this code only ever executes during the test suite, and even
         # though only when mocking `snap` for speed, this is always safe.
@@ -99,7 +101,8 @@ class SecondAndOnwardMock(MockerBase):
 class AlwaysMock(MockerBase):
     def snap_mock(self, model_assertion, root_dir, workdir,
                   channel=None, extra_snaps=None,
-                  cloud_init=None, disable_console_conf=None):
+                  cloud_init=None, disable_console_conf=None,
+                  factory_image=None):
         zipfile = resource_filename(
             'ubuntu_image.tests.data',
             '{}.zip'.format(self._checksum(model_assertion, channel)))

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -91,6 +91,7 @@ class TestModelAssertionBuilder(TestCase):
             hooks_directory=[],
             disk_info=None,
             disable_console_conf=False,
+            factory_image=False,
             )
         state = self._resources.enter_context(XXXModelAssertionBuilder(args))
         state.run_thru('populate_bootfs_contents')
@@ -159,6 +160,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -199,6 +201,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -241,6 +244,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -280,6 +284,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -320,6 +325,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -359,6 +365,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -403,6 +410,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -465,6 +473,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -513,6 +522,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -630,6 +640,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -696,6 +707,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -789,6 +801,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -842,6 +855,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -900,6 +914,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -995,6 +1010,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1066,6 +1082,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1126,6 +1143,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1208,6 +1226,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1278,6 +1297,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1380,6 +1400,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1432,6 +1453,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1561,6 +1583,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1651,6 +1674,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1739,6 +1763,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1871,6 +1896,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1943,6 +1969,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2025,6 +2052,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2084,6 +2112,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2129,6 +2158,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2186,6 +2216,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2263,6 +2294,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2317,6 +2349,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2379,6 +2412,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2432,6 +2466,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2487,6 +2522,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2555,6 +2591,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2644,6 +2681,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2704,6 +2742,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2772,6 +2811,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2854,6 +2894,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2914,6 +2955,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2983,6 +3025,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3053,6 +3096,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3130,6 +3174,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3179,6 +3224,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3227,6 +3273,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3279,6 +3326,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3327,6 +3375,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=diskinfo,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3354,6 +3403,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3394,6 +3444,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3440,6 +3491,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -3481,6 +3533,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -3509,6 +3562,7 @@ class TestModelAssertionBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state.unpackdir = resources.enter_context(TemporaryDirectory())
@@ -3560,6 +3614,7 @@ class TestModelAssertionBuilder(TestCase):
                 cloud_init=None,
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 debug=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))

--- a/ubuntu_image/tests/test_classic_builder.py
+++ b/ubuntu_image/tests/test_classic_builder.py
@@ -80,6 +80,7 @@ class TestClassicBuilder(TestCase):
             hooks_directory=[],
             disk_info=None,
             disable_console_conf=False,
+            factory_image=False,
             gadget_tree=self.gadget_tree,
             filesystem=None,
             )
@@ -125,6 +126,7 @@ class TestClassicBuilder(TestCase):
             hooks_directory=[],
             disk_info=None,
             disable_console_conf=False,
+            factory_image=False,
             gadget_tree=self.gadget_tree,
             filesystem=None,
             )
@@ -172,6 +174,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -231,6 +234,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -290,6 +294,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -351,6 +356,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -412,6 +418,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -475,6 +482,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -545,6 +553,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -639,6 +648,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -694,6 +704,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -758,6 +769,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -867,6 +879,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -918,6 +931,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -964,6 +978,7 @@ class TestClassicBuilder(TestCase):
                 'hooks_directory': '/tmp',
                 'disk_info': None,
                 'disable_console_conf': False,
+                'factory_image': False,
                 'output': None,
                 'cloud_init': None,
                 'gadget_tree': None,
@@ -1034,6 +1049,7 @@ class TestClassicBuilder(TestCase):
                 'hooks_directory': '/tmp',
                 'disk_info': None,
                 'disable_console_conf': False,
+                'factory_image': False,
                 'output': None,
                 'cloud_init': None,
                 'gadget_tree': None,
@@ -1089,6 +1105,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -1150,6 +1167,7 @@ class TestClassicBuilder(TestCase):
                 hooks_directory=[],
                 disk_info=None,
                 disable_console_conf=False,
+                factory_image=False,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -289,6 +289,9 @@ class TestHelpers(TestCase):
               'disable_console_conf': True},
              {'cloud-init-user-data': '/foo/bar/user-data',
               'console-conf': 'disabled'}),
+            # --factory-image (UC20 only)
+            ({'factory_image': True},
+             {'boot-flags': ['factory']}),
         )
         for kwargs, result in test_cases:
             with ExitStack() as resources:


### PR DESCRIPTION
This applies a hint that the image is meant to be booted in a device
factory by setting the factory boot-flag via prepare-image
customizations.