### PR TITLE
Add --validation command option

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,7 @@ ubuntu-image (1.11+21.04ubuntu3) UNRELEASED; urgency=medium
 
   [ Samuele Pedroni ]
   * Add --factory-image command option.  (LP: #1929236)
+  * Add --validation command option.
 
  -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Fri, 21 May 2021 18:10:41 +0200
 

--- a/ubuntu_image/__main__.py
+++ b/ubuntu_image/__main__.py
@@ -261,6 +261,12 @@ def parseargs(argv=None):
         default=False, action='store_true',
         help=_("""Hint that the image is meant to boot in a device
         factory."""))
+    snap_cmd.add_argument(
+        '--validation',
+        default=None, action='store', choices=['ignore', 'enforce'],
+        help=_("""Control whether validations should be ignored or
+        enforced.""")
+        )
     # Classic-based image options.
     classic_cmd.add_argument(
         'gadget_tree', nargs='?',
@@ -332,6 +338,8 @@ def parseargs(argv=None):
         args.disable_console_conf = False
         # nor has a concept of factory images
         args.factory_image = False
+        # no validations either
+        args.validation = None
     if args.resume and args.workdir is None:
         parser.error('--resume requires --workdir')
     # --until and --thru can take an int.

--- a/ubuntu_image/assertion_builder.py
+++ b/ubuntu_image/assertion_builder.py
@@ -26,7 +26,7 @@ class ModelAssertionBuilder(AbstractImageBuilderState):
                  channel=self.args.channel, extra_snaps=extra_snaps,
                  cloud_init=self.cloud_init,
                  disable_console_conf=self.disable_console_conf,
-                 factory_image=self.factory_image)
+                 factory_image=self.factory_image, validation=self.validation)
         except CalledProcessError:
             if self.args.debug:
                 _logger.exception('Full debug traceback follows')

--- a/ubuntu_image/common_builder.py
+++ b/ubuntu_image/common_builder.py
@@ -62,6 +62,7 @@ class AbstractImageBuilderState(State):
         self.disk_info = args.disk_info
         self.disable_console_conf = args.disable_console_conf
         self.factory_image = args.factory_image
+        self.validation = args.validation
         self.exitcode = 0
         self.done = False
         # Generic hook handling manager.
@@ -77,6 +78,7 @@ class AbstractImageBuilderState(State):
             disk_info=self.disk_info,
             disable_console_conf=self.disable_console_conf,
             factory_image=self.factory_image,
+            validation=self.validation,
             done=self.done,
             exitcode=self.exitcode,
             gadget=self.gadget,
@@ -99,6 +101,7 @@ class AbstractImageBuilderState(State):
         self.disk_info = state['disk_info']
         self.disable_console_conf = state['disable_console_conf']
         self.factory_image = state['factory_image']
+        self.validation = state['validation']
         self.done = state['done']
         self.exitcode = state['exitcode']
         self.gadget = state['gadget']

--- a/ubuntu_image/helpers.py
+++ b/ubuntu_image/helpers.py
@@ -126,7 +126,8 @@ def run(command, *, check=True, **args):
 
 
 def snap(model_assertion, root_dir, workdir, channel=None, extra_snaps=None,
-         cloud_init=None, disable_console_conf=None, factory_image=None):
+         cloud_init=None, disable_console_conf=None, factory_image=None,
+         validation=None):
     snap_cmd = os.environ.get('UBUNTU_IMAGE_SNAP_CMD', 'snap')
     # Create a list of the command arguments to run.  We do it this way rather
     # than just .format() into a template string in order to have a more
@@ -149,6 +150,10 @@ def snap(model_assertion, root_dir, workdir, channel=None, extra_snaps=None,
     if factory_image:
         # The factory image hint for UC20 is set as a boot flag
         customize['boot-flags'] = ['factory']
+    if validation:
+        # The default behavior is encoded in prepare-image, pass the
+        # option if set
+        customize['validation'] = validation
     if customize:
         customize_path = os.path.join(workdir, 'customization')
         with open(customize_path, 'w') as fp:

--- a/ubuntu_image/testing/nose.py
+++ b/ubuntu_image/testing/nose.py
@@ -79,7 +79,7 @@ class SecondAndOnwardMock(MockerBase):
     def snap_mock(self, model_assertion, root_dir, workdir,
                   channel=None, extra_snaps=None,
                   cloud_init=None, disable_console_conf=None,
-                  factory_image=None):
+                  factory_image=None, validation=None):
         run_tmp = os.path.join(
             self._tmpdir,
             self._checksum(model_assertion, channel))
@@ -90,7 +90,7 @@ class SecondAndOnwardMock(MockerBase):
                 real_snap(model_assertion, tmp_root, self._tmpdir, channel,
                           cloud_init=cloud_init,
                           disable_console_conf=disable_console_conf,
-                          factory_image=factory_image)
+                          factory_image=factory_image, validation=validation)
         # copytree() requires that the destination directories do not exist.
         # Since this code only ever executes during the test suite, and even
         # though only when mocking `snap` for speed, this is always safe.
@@ -102,7 +102,7 @@ class AlwaysMock(MockerBase):
     def snap_mock(self, model_assertion, root_dir, workdir,
                   channel=None, extra_snaps=None,
                   cloud_init=None, disable_console_conf=None,
-                  factory_image=None):
+                  factory_image=None, validation=None):
         zipfile = resource_filename(
             'ubuntu_image.tests.data',
             '{}.zip'.format(self._checksum(model_assertion, channel)))

--- a/ubuntu_image/tests/test_builder.py
+++ b/ubuntu_image/tests/test_builder.py
@@ -92,6 +92,7 @@ class TestModelAssertionBuilder(TestCase):
             disk_info=None,
             disable_console_conf=False,
             factory_image=False,
+            validation=None,
             )
         state = self._resources.enter_context(XXXModelAssertionBuilder(args))
         state.run_thru('populate_bootfs_contents')
@@ -161,6 +162,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -202,6 +204,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -245,6 +248,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -285,6 +289,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -326,6 +331,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -366,6 +372,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             # Fake some state expected by the method under test.
@@ -411,6 +418,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -474,6 +482,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -523,6 +532,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -641,6 +651,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -708,6 +719,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -802,6 +814,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -856,6 +869,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -915,6 +929,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1011,6 +1026,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1083,6 +1099,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1144,6 +1161,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1227,6 +1245,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1298,6 +1317,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 cmd='snap',
                 )
             # Jump right to the method under test.
@@ -1401,6 +1421,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1454,6 +1475,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1584,6 +1606,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1675,6 +1698,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1764,6 +1788,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1897,6 +1922,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -1970,6 +1996,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2053,6 +2080,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2113,6 +2141,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2159,6 +2188,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2217,6 +2247,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2295,6 +2326,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2350,6 +2382,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2413,6 +2446,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2467,6 +2501,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2523,6 +2558,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2592,6 +2628,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2682,6 +2719,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2743,6 +2781,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2812,6 +2851,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2895,6 +2935,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -2956,6 +2997,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3026,6 +3068,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3097,6 +3140,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3175,6 +3219,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3225,6 +3270,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3274,6 +3320,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3327,6 +3374,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3376,6 +3424,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=diskinfo,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3404,6 +3453,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3445,6 +3495,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             # Jump right to the method under test.
             state = resources.enter_context(XXXModelAssertionBuilder(args))
@@ -3492,6 +3543,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -3534,6 +3586,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state._next.pop()
@@ -3563,6 +3616,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))
             state.unpackdir = resources.enter_context(TemporaryDirectory())
@@ -3615,6 +3669,7 @@ class TestModelAssertionBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 debug=False,
                 )
             state = resources.enter_context(XXXModelAssertionBuilder(args))

--- a/ubuntu_image/tests/test_classic_builder.py
+++ b/ubuntu_image/tests/test_classic_builder.py
@@ -81,6 +81,7 @@ class TestClassicBuilder(TestCase):
             disk_info=None,
             disable_console_conf=False,
             factory_image=False,
+            validation=None,
             gadget_tree=self.gadget_tree,
             filesystem=None,
             )
@@ -127,6 +128,7 @@ class TestClassicBuilder(TestCase):
             disk_info=None,
             disable_console_conf=False,
             factory_image=False,
+            validation=None,
             gadget_tree=self.gadget_tree,
             filesystem=None,
             )
@@ -175,6 +177,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -235,6 +238,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -295,6 +299,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -357,6 +362,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -419,6 +425,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -483,6 +490,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -554,6 +562,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -649,6 +658,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -705,6 +715,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -770,6 +781,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -880,6 +892,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -932,6 +945,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -979,6 +993,7 @@ class TestClassicBuilder(TestCase):
                 'disk_info': None,
                 'disable_console_conf': False,
                 'factory_image': False,
+                'validation': None,
                 'output': None,
                 'cloud_init': None,
                 'gadget_tree': None,
@@ -1050,6 +1065,7 @@ class TestClassicBuilder(TestCase):
                 'disk_info': None,
                 'disable_console_conf': False,
                 'factory_image': False,
+                'validation': None,
                 'output': None,
                 'cloud_init': None,
                 'gadget_tree': None,
@@ -1106,6 +1122,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )
@@ -1168,6 +1185,7 @@ class TestClassicBuilder(TestCase):
                 disk_info=None,
                 disable_console_conf=False,
                 factory_image=False,
+                validation=None,
                 gadget_tree=self.gadget_tree,
                 filesystem=None,
                 )

--- a/ubuntu_image/tests/test_helpers.py
+++ b/ubuntu_image/tests/test_helpers.py
@@ -292,6 +292,11 @@ class TestHelpers(TestCase):
             # --factory-image (UC20 only)
             ({'factory_image': True},
              {'boot-flags': ['factory']}),
+            # --validation=enforce|ignore
+            ({'validation': 'enforce'},
+             {'validation': 'enforce'}),
+            ({'validation': 'ignore'},
+             {'validation': 'ignore'}),
         )
         for kwargs, result in test_cases:
             with ExitStack() as resources:


### PR DESCRIPTION
This is passed along to snapd as a customization field to control
whether validations are enforced or ignored fetching the snaps to
prepare the image.